### PR TITLE
feat: created Demographics Service stub function

### DIFF
--- a/src/BIAnalyticsService/CreateDataAssets/local.settings.json.template
+++ b/src/BIAnalyticsService/CreateDataAssets/local.settings.json.template
@@ -6,7 +6,8 @@
     "GetEpisodeUrl": "http://localhost:6060/api/GetEpisode",
     "GetParticipantUrl": "http://localhost:6061/api/GetParticipant",
     "CreateParticipantScreeningEpisodeUrl":"http://localhost:6010/api/CreateParticipantScreeningEpisode",
-    "CreateParticipantScreeningProfileUrl":"http://localhost:6011/api/CreateParticipantScreeningProfile"
+    "CreateParticipantScreeningProfileUrl":"http://localhost:6011/api/CreateParticipantScreeningProfile",
+    "DemographicsServiceUrl": "http://localhost:6080/api/GetDemographicsData"
   },
   "Host": {
     "LocalHttpPort": 6009

--- a/src/DemographicsService/GetDemographicsData/GetDemographicsData.cs
+++ b/src/DemographicsService/GetDemographicsData/GetDemographicsData.cs
@@ -1,0 +1,49 @@
+using System.Net;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
+using NHS.ServiceInsights.Model;
+
+namespace NHS.ServiceInsights.DemographicsService;
+
+public class GetDemographicsData
+{
+    private readonly ILogger<GetDemographicsData> _logger;
+
+
+    public GetDemographicsData(ILogger<GetDemographicsData> logger)
+    {
+        _logger = logger;
+
+    }
+
+    [Function("GetDemographicsData")]
+    public async Task<HttpResponseData> Run([HttpTrigger(AuthorizationLevel.Anonymous, "get")] HttpRequestData req)
+    {
+        _logger.LogInformation("Request to retrieve a participant's demographic information has been processed.");
+
+        string nhsNumber = req.Query["nhs_number"];
+
+        if (string.IsNullOrEmpty(nhsNumber))
+        {
+            _logger.LogError("Please enter a valid NHS Number.");
+            return req.CreateResponse(HttpStatusCode.BadRequest);
+        }
+
+        DemographicsData demographicsData = new DemographicsData
+        {
+            PrimaryCareProvider = "A81002",
+            PreferredLanguage = "EN"
+        };
+
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        response.Headers.Add("Content-Type", "application/json");
+        var json = JsonSerializer.Serialize(demographicsData);
+        await response.WriteStringAsync(json);
+        return response;
+    }
+}
+
+
+

--- a/src/DemographicsService/GetDemographicsData/GetDemographicsData.cs
+++ b/src/DemographicsService/GetDemographicsData/GetDemographicsData.cs
@@ -27,7 +27,7 @@ public class GetDemographicsData
 
         if (string.IsNullOrEmpty(nhsNumber))
         {
-            _logger.LogError("Please enter a valid NHS Number.");
+            _logger.LogError("Missing NHS Number.");
             return req.CreateResponse(HttpStatusCode.BadRequest);
         }
 

--- a/src/DemographicsService/GetDemographicsData/GetDemographicsData.csproj
+++ b/src/DemographicsService/GetDemographicsData/GetDemographicsData.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.19.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.15.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="System.Threading.ExecutionContext" Alias="ExecutionContext" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Shared\Model\Model.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/DemographicsService/GetDemographicsData/Program.cs
+++ b/src/DemographicsService/GetDemographicsData/Program.cs
@@ -1,0 +1,11 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+var host = new HostBuilder()
+    .ConfigureFunctionsWorkerDefaults()
+    .ConfigureServices(services =>
+    {
+
+    })
+    .Build();
+host.Run();

--- a/src/DemographicsService/GetDemographicsData/Properties/launchSettings.json
+++ b/src/DemographicsService/GetDemographicsData/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+{
+  "profiles": {
+    "DemographicsService": {
+      "commandName": "Project",
+      "commandLineArgs": "--port 7233",
+      "launchBrowser": false
+    }
+  }
+}

--- a/src/DemographicsService/GetDemographicsData/host.json
+++ b/src/DemographicsService/GetDemographicsData/host.json
@@ -1,0 +1,12 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      },
+      "enableLiveMetricsFilters": true
+    }
+  }
+}

--- a/src/DemographicsService/GetDemographicsData/local.settings.json.template
+++ b/src/DemographicsService/GetDemographicsData/local.settings.json.template
@@ -1,0 +1,10 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated"
+  },
+  "Host": {
+    "LocalHttpPort": 6080
+  }
+}

--- a/src/ServiceInsights.sln
+++ b/src/ServiceInsights.sln
@@ -87,6 +87,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CreateDataAssets", "BIAnaly
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CreateDataAssetsTests", "..\tests\BIAnalyticsServiceTests\CreateDataAssetsTests\CreateDataAssetsTests.csproj", "{36FDD9C2-830C-4A76-BF1F-C012C3ED8425}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DemographicsService", "DemographicsService", "{1A0A629C-9BA1-4A19-8253-5137C2C0BA0B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GetDemographicsData", "DemographicsService\GetDemographicsData\GetDemographicsData.csproj", "{8004251F-AF5A-4030-B40F-0C3EA8948040}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GetDemographicsDataTests", "..\tests\DemographicsServiceTests\GetDemographicsDataTests\GetDemographicsDataTests.csproj", "{5AC79E9B-0FC9-4B3F-9049-81419C6E41B2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -221,6 +227,14 @@ Global
 		{36FDD9C2-830C-4A76-BF1F-C012C3ED8425}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{36FDD9C2-830C-4A76-BF1F-C012C3ED8425}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{36FDD9C2-830C-4A76-BF1F-C012C3ED8425}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8004251F-AF5A-4030-B40F-0C3EA8948040}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8004251F-AF5A-4030-B40F-0C3EA8948040}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8004251F-AF5A-4030-B40F-0C3EA8948040}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8004251F-AF5A-4030-B40F-0C3EA8948040}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5AC79E9B-0FC9-4B3F-9049-81419C6E41B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5AC79E9B-0FC9-4B3F-9049-81419C6E41B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5AC79E9B-0FC9-4B3F-9049-81419C6E41B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5AC79E9B-0FC9-4B3F-9049-81419C6E41B2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -246,5 +260,6 @@ Global
 		{248A6EA6-7616-4BC9-9CA7-C9E3C7A0C1EA} = {4CBE2AE3-2FFC-46BE-8727-0B128F849495}
 		{E3459DCC-85DA-4B35-920F-5661E6F63D52} = {DACA4EB5-14F5-42D8-AD61-DA1FA4DBB6ED}
 		{A6C9E7C1-7A8A-41F9-A08C-F26D92C3F759} = {4B0AD4B3-4508-4F6B-AEBF-24B4578DB1DC}
+		{8004251F-AF5A-4030-B40F-0C3EA8948040} = {1A0A629C-9BA1-4A19-8253-5137C2C0BA0B}
 	EndGlobalSection
 EndGlobal

--- a/src/Shared/Model/DemographicsData.cs
+++ b/src/Shared/Model/DemographicsData.cs
@@ -1,0 +1,6 @@
+namespace NHS.ServiceInsights.Model;
+public class DemographicsData
+{
+    public string PrimaryCareProvider {get; set;}
+    public string PreferredLanguage {get; set;}
+}

--- a/tests/DemographicsServiceTests/GetDemographicsDataTests/GetDemographicsDataTests.cs
+++ b/tests/DemographicsServiceTests/GetDemographicsDataTests/GetDemographicsDataTests.cs
@@ -1,0 +1,75 @@
+using Moq;
+using System.Net;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using NHS.ServiceInsights.DemographicsService;
+using NHS.ServiceInsights.TestUtils;
+using NHS.ServiceInsights.Common;
+using System.Collections.Specialized;
+
+namespace NHS.ServiceInsights.DemographicsServiceTests;
+
+[TestClass]
+public class GetDemographicsDataTests
+{
+    private Mock<ILogger<GetDemographicsData>> _mockLogger = new();
+    private Mock<IHttpRequestService> _mockHttpRequestService = new();
+    private GetDemographicsData _function;
+    private Mock<HttpRequestData> _mockRequest = new();
+    private SetupRequest _setupRequest = new();
+
+
+    public GetDemographicsDataTests()
+    {
+        _function = new GetDemographicsData(_mockLogger.Object);
+    }
+
+    [TestMethod]
+    public async Task Run_ShouldReturnBadRequest_WhenNhsNumberIsNotProvided()
+    {
+        // Arrange
+        var queryParam = new NameValueCollection
+        {
+            {
+                "nhs_number", null
+            }
+        };
+
+        _mockRequest = _setupRequest.SetupGet(queryParam);
+
+        // Act
+        var response = await _function.Run(_mockRequest.Object);
+
+        // Assert
+        Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+        _mockLogger.Verify(log =>
+            log.Log(
+            LogLevel.Error,
+            0,
+            It.Is<It.IsAnyType>((state, type) => state.ToString() == "Please enter a valid NHS Number."),
+            null,
+            (Func<object, Exception, string>)It.IsAny<object>()),
+            Times.Once);
+    }
+
+
+    [TestMethod]
+    public async Task Run_ShouldReturnOk_WhenNhsNumberIsProvided()
+    {
+        // Arrange
+        var queryParam = new NameValueCollection
+        {
+            {
+                "nhs_number", "1111111112"
+            }
+        };
+
+        _mockRequest = _setupRequest.SetupGet(queryParam);
+
+        // Act
+        var response = await _function.Run(_mockRequest.Object);
+
+        // Assert
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+    }
+}

--- a/tests/DemographicsServiceTests/GetDemographicsDataTests/GetDemographicsDataTests.cs
+++ b/tests/DemographicsServiceTests/GetDemographicsDataTests/GetDemographicsDataTests.cs
@@ -46,7 +46,7 @@ public class GetDemographicsDataTests
             log.Log(
             LogLevel.Error,
             0,
-            It.Is<It.IsAnyType>((state, type) => state.ToString() == "Please enter a valid NHS Number."),
+            It.Is<It.IsAnyType>((state, type) => state.ToString() == "Missing NHS Number."),
             null,
             (Func<object, Exception, string>)It.IsAny<object>()),
             Times.Once);

--- a/tests/DemographicsServiceTests/GetDemographicsDataTests/GetDemographicsDataTests.csproj
+++ b/tests/DemographicsServiceTests/GetDemographicsDataTests/GetDemographicsDataTests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+<ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\DemographicsService\GetDemographicsData\GetDemographicsData.csproj" />
+    <ProjectReference Include="..\..\TestUtils\TestUtils.csproj" />
+    <ProjectReference Include="..\..\..\src\Shared\Common\Common.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Created the stub Demographics Service and its GetDemographicsData Azure function. Its goal is to create hardcoded demographics data for the 'Primary Care Provider' and 'Preferred Language' properties. This will be called by the CreateDataAssets function. After calling the demographics service, CreateDataAssets retrieves the values for 'Primary Care Provider' and 'Preferred Language', and maps them to the Participant Screening Profile table.

Created two unit tests for this stub. One that checks an OK response, and another that checks for a BadRequest.

In the future, we aim to get this demographics data from Cohort Manager. However, for now, we have a stub function for it.

The class for the Demographics Data is stored in Shared/Model

## Context

Before these changes, the Participant Screening Profile table was being mapped using only the 'Participant' model. However, this model does not contain the values for 'Primary Care Provider' and 'Preferred Language'. This is demographics data that needs to be retrieved from another source. The GetDemographicsData function acts as the source for now. This ensures that the Participant Screening Profile table contains the right values for these two properties.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [x] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
