### PR TITLE
feat: Validate name and extension of files retrieved from MESH

### DIFF
--- a/src/MeshIntegrationService/RetrieveMeshFile/RetrieveMeshFile.cs
+++ b/src/MeshIntegrationService/RetrieveMeshFile/RetrieveMeshFile.cs
@@ -33,7 +33,8 @@ public class RetrieveMeshFile
     {
         _logger.LogInformation($"C# Timer trigger function executed at: {DateTime.Now}");
 
-        static bool messageFilter(MessageMetaData i) => true; // No current filter defined there might be business rules here
+        static bool messageFilter(MessageMetaData i) =>
+            (i.FileName.StartsWith("bss_subjects") || i.FileName.StartsWith("bss_episodes")) && i.FileName.EndsWith(".csv");
 
         try
         {

--- a/src/ParticipantManagementService/UpdateParticipant/Participant.cs
+++ b/src/ParticipantManagementService/UpdateParticipant/Participant.cs
@@ -1,4 +1,4 @@
 public class Participant
 {
-  public string NhsNumber { get; set; }
+    public string NhsNumber { get; set; }
 }

--- a/src/Shared/Common/MeshToBlobTransferHandler.cs
+++ b/src/Shared/Common/MeshToBlobTransferHandler.cs
@@ -83,7 +83,7 @@ public class MeshToBlobTransferHandler : IMeshToBlobTransferHandler
             }
             if (!predicate(messageHead.Response.MessageMetaData))
             {
-                _logger.LogInformation("Message: {MessageId} was did not meet the predicate for transferring to BlobStorage", messageHead.Response.MessageMetaData.MessageId);
+                _logger.LogInformation("Message: {MessageId} did not meet the predicate for transferring to BlobStorage", messageHead.Response.MessageMetaData.MessageId);
                 continue;
             }
             bool wasMessageDownloaded = await TransferMessageToBlobStorage(messageHead.Response.MessageMetaData);

--- a/tests/MeshIntegrationServiceTests/RetrieveMeshFileTests/MeshResponseTestHelper.cs
+++ b/tests/MeshIntegrationServiceTests/RetrieveMeshFileTests/MeshResponseTestHelper.cs
@@ -16,7 +16,7 @@ public static class MeshResponseTestHelper
         };
     }
 
-    public static MessageMetaData CreateMessageMetaData(string mailboxId, string messageId, string? filename = null, string? messageType = "DATA", string? chunkRange = null, int? TotalChunks = null)
+    public static MessageMetaData CreateMessageMetaData(string mailboxId, string messageId, string? filename = "bss_episodes.csv", string? messageType = "DATA", string? chunkRange = null, int? TotalChunks = null)
     {
         return new MessageMetaData
         {
@@ -31,7 +31,7 @@ public static class MeshResponseTestHelper
         };
     }
 
-    public static MeshResponse<HeadMessageResponse> CreateSuccessfulMeshHeadResponse(string mailboxId, string messageId, string? filename = null, string? messageType = "DATA", string? chunkRange = null, int? TotalChunks = null)
+    public static MeshResponse<HeadMessageResponse> CreateSuccessfulMeshHeadResponse(string mailboxId, string messageId, string? filename = "bss_episodes.csv", string? messageType = "DATA", string? chunkRange = null, int? TotalChunks = null)
     {
         return new MeshResponse<HeadMessageResponse>
         {

--- a/tests/MeshIntegrationServiceTests/RetrieveMeshFileTests/RetrieveMeshFileTests.cs
+++ b/tests/MeshIntegrationServiceTests/RetrieveMeshFileTests/RetrieveMeshFileTests.cs
@@ -327,44 +327,16 @@ public class RetrieveMeshFileTests
     }
 
     [TestMethod]
-    public async Task Run_DoesNotTransferFile_IfFileNameIsInvalid()
+    [DataRow("invalid_file.csv", "application/csv")]
+    [DataRow("bss_episodes.json", "application/json")]
+    public async Task Run_DoesNotTransferFile_IfFileNameIsInvalid(string invalidFileName, string contentType)
     {
         //arrange
         var messageId = "MessageId";
-        var invalidFileName = "invalid_file.csv";
         var content = System.Text.Encoding.UTF8.GetBytes("{}");
         MeshResponse<CheckInboxResponse> inboxResponse = MeshResponseTestHelper.CreateSuccessfulCheckInboxResponse([messageId]);
         MeshResponse<HeadMessageResponse> headResponse = MeshResponseTestHelper.CreateSuccessfulMeshHeadResponse(mailboxId, messageId, invalidFileName);
-        MeshResponse<GetMessageResponse> messageResponse = MeshResponseTestHelper.CreateSuccessfulGetMessageResponse(mailboxId, messageId, invalidFileName, content, "application/csv");
-        MeshResponse<AcknowledgeMessageResponse> acknowledgeMessageResponse = MeshResponseTestHelper.CreateSuccessfulAcknowledgeResponse(messageId);
-
-        _mockMeshInboxService.Setup(i => i.GetMessagesAsync(mailboxId)).ReturnsAsync(inboxResponse);
-        _mockMeshInboxService.Setup(i => i.GetHeadMessageByIdAsync(mailboxId, messageId)).ReturnsAsync(headResponse);
-        _mockMeshInboxService.Setup(i => i.GetMessageByIdAsync(mailboxId, messageId)).ReturnsAsync(messageResponse);
-        _mockBlobStorageHelper.Setup(i => i.UploadFileToBlobStorage("BlobStorage_ConnectionString", "inbound", It.IsAny<BlobFile>())).ReturnsAsync(true);
-        _mockMeshInboxService.Setup(i => i.AcknowledgeMessageByIdAsync(mailboxId, messageId)).ReturnsAsync(acknowledgeMessageResponse);
-
-        //act
-        await _retrieveMeshFile.RunAsync(new Microsoft.Azure.Functions.Worker.TimerInfo());
-
-        //assert
-        _mockMeshInboxService.Verify(i => i.GetMessagesAsync(It.IsAny<string>()), Times.Once);
-        _mockMeshInboxService.Verify(i => i.GetHeadMessageByIdAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
-        _mockMeshInboxService.Verify(i => i.GetMessageByIdAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-        _mockBlobStorageHelper.Verify(i => i.UploadFileToBlobStorage(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<BlobFile>()), Times.Never);
-        _mockMeshInboxService.Verify(i => i.AcknowledgeMessageByIdAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-    }
-
-    [TestMethod]
-    public async Task Run_DoesNotTransferFile_IfFileExtensionIsInvalid()
-    {
-        //arrange
-        var messageId = "MessageId";
-        var invalidFileName = "bss_episodes.json";
-        var content = System.Text.Encoding.UTF8.GetBytes("{}");
-        MeshResponse<CheckInboxResponse> inboxResponse = MeshResponseTestHelper.CreateSuccessfulCheckInboxResponse([messageId]);
-        MeshResponse<HeadMessageResponse> headResponse = MeshResponseTestHelper.CreateSuccessfulMeshHeadResponse(mailboxId, messageId, invalidFileName);
-        MeshResponse<GetMessageResponse> messageResponse = MeshResponseTestHelper.CreateSuccessfulGetMessageResponse(mailboxId, messageId, invalidFileName, content, "application/json");
+        MeshResponse<GetMessageResponse> messageResponse = MeshResponseTestHelper.CreateSuccessfulGetMessageResponse(mailboxId, messageId, invalidFileName, content, contentType);
         MeshResponse<AcknowledgeMessageResponse> acknowledgeMessageResponse = MeshResponseTestHelper.CreateSuccessfulAcknowledgeResponse(messageId);
 
         _mockMeshInboxService.Setup(i => i.GetMessagesAsync(mailboxId)).ReturnsAsync(inboxResponse);

--- a/tests/MeshIntegrationServiceTests/RetrieveMeshFileTests/RetrieveMeshFileTests.cs
+++ b/tests/MeshIntegrationServiceTests/RetrieveMeshFileTests/RetrieveMeshFileTests.cs
@@ -35,12 +35,12 @@ public class RetrieveMeshFileTests
     {
         //arrange
         var messageId = "MessageId";
-        var fileName = "testFile.json";
+        var fileName = "bss_episodes.csv";
         var content = System.Text.Encoding.UTF8.GetBytes("{}");
 
         MeshResponse<CheckInboxResponse> inboxResponse = MeshResponseTestHelper.CreateSuccessfulCheckInboxResponse([messageId]);
         MeshResponse<HeadMessageResponse> headResponse = MeshResponseTestHelper.CreateSuccessfulMeshHeadResponse(mailboxId, messageId, fileName);
-        MeshResponse<GetMessageResponse> messageResponse = MeshResponseTestHelper.CreateSuccessfulGetMessageResponse(mailboxId, messageId, fileName, content, "application/json");
+        MeshResponse<GetMessageResponse> messageResponse = MeshResponseTestHelper.CreateSuccessfulGetMessageResponse(mailboxId, messageId, fileName, content, "application/csv");
         MeshResponse<AcknowledgeMessageResponse> acknowledgeMessageResponse = MeshResponseTestHelper.CreateSuccessfulAcknowledgeResponse(messageId);
 
         _mockMeshInboxService.Setup(i => i.GetMessagesAsync(mailboxId)).ReturnsAsync(inboxResponse);
@@ -68,13 +68,13 @@ public class RetrieveMeshFileTests
     {
         //arrange
         var messageId = "MessageId";
-        var fileName = "testFile.json";
+        var fileName = "bss_episodes.csv";
 
         var content = new List<byte[]> { System.Text.Encoding.UTF8.GetBytes("{}"), System.Text.Encoding.UTF8.GetBytes("{}") };
 
         MeshResponse<CheckInboxResponse> inboxResponse = MeshResponseTestHelper.CreateSuccessfulCheckInboxResponse([messageId]);
         MeshResponse<HeadMessageResponse> headResponse = MeshResponseTestHelper.CreateSuccessfulMeshHeadResponse(mailboxId, messageId, fileName, "DATA", "1:2", 2);
-        MeshResponse<GetChunkedMessageResponse> messageResponse = MeshResponseTestHelper.CreateSuccessfulGetChunkedMessageResponse(mailboxId, messageId, fileName, "application/json", content);
+        MeshResponse<GetChunkedMessageResponse> messageResponse = MeshResponseTestHelper.CreateSuccessfulGetChunkedMessageResponse(mailboxId, messageId, fileName, "application/csv", content);
         MeshResponse<AcknowledgeMessageResponse> acknowledgeMessageResponse = MeshResponseTestHelper.CreateSuccessfulAcknowledgeResponse(messageId);
 
         _mockMeshInboxService.Setup(i => i.GetMessagesAsync(mailboxId)).ReturnsAsync(inboxResponse);
@@ -110,7 +110,7 @@ public class RetrieveMeshFileTests
         foreach (var message in messages)
         {
             headResponses.Enqueue(MeshResponseTestHelper.CreateSuccessfulMeshHeadResponse(mailboxId, message));
-            messageResponses.Enqueue(MeshResponseTestHelper.CreateSuccessfulGetMessageResponse(mailboxId, message, "File.json", content, "application/json"));
+            messageResponses.Enqueue(MeshResponseTestHelper.CreateSuccessfulGetMessageResponse(mailboxId, message, "bss_episodes.csv", content, "application/csv"));
         }
         MeshResponse<AcknowledgeMessageResponse> acknowledgeMessageResponse = MeshResponseTestHelper.CreateSuccessfulAcknowledgeResponse("DummyData");
 
@@ -157,11 +157,11 @@ public class RetrieveMeshFileTests
     {
         //arrange
         var messageId = "MessageId";
-        var fileName = "testFile.json";
+        var fileName = "bss_episodes.csv";
         var content = System.Text.Encoding.UTF8.GetBytes("{}");
         MeshResponse<CheckInboxResponse> inboxResponse = MeshResponseTestHelper.CreateSuccessfulCheckInboxResponse([messageId]);
         MeshResponse<HeadMessageResponse> headResponse = MeshResponseTestHelper.CreateSuccessfulMeshHeadResponse(mailboxId, messageId, fileName);
-        MeshResponse<GetMessageResponse> messageResponse = MeshResponseTestHelper.CreateSuccessfulGetMessageResponse(mailboxId, messageId, fileName, content, "application/json");
+        MeshResponse<GetMessageResponse> messageResponse = MeshResponseTestHelper.CreateSuccessfulGetMessageResponse(mailboxId, messageId, fileName, content, "application/csv");
         MeshResponse<AcknowledgeMessageResponse> acknowledgeMessageResponse = MeshResponseTestHelper.CreateSuccessfulAcknowledgeResponse(messageId);
 
         _mockMeshInboxService.Setup(i => i.GetMessagesAsync(mailboxId)).ReturnsAsync(inboxResponse);
@@ -186,7 +186,7 @@ public class RetrieveMeshFileTests
     {
         //arrange
         var messageId = "MessageId";
-        var fileName = "testFile.json";
+        var fileName = "bss_episodes.csv";
         var content = System.Text.Encoding.UTF8.GetBytes("{}");
         MeshResponse<CheckInboxResponse> inboxResponse = MeshResponseTestHelper.CreateSuccessfulCheckInboxResponse([messageId]);
         MeshResponse<HeadMessageResponse> headResponse = new MeshResponse<HeadMessageResponse>
@@ -223,7 +223,7 @@ public class RetrieveMeshFileTests
     {
         //arrange
         var messageId = "MessageId";
-        var fileName = "testFile.json";
+        var fileName = "bss_episodes.csv";
         var content = System.Text.Encoding.UTF8.GetBytes("{}");
         MeshResponse<CheckInboxResponse> inboxResponse = MeshResponseTestHelper.CreateSuccessfulCheckInboxResponse([messageId]);
         MeshResponse<HeadMessageResponse> headResponse = MeshResponseTestHelper.CreateSuccessfulMeshHeadResponse(mailboxId, messageId, fileName);
@@ -293,7 +293,7 @@ public class RetrieveMeshFileTests
     {
         //arrange
         var messageId = "MessageId";
-        var fileName = "testFile.json";
+        var fileName = "bss_episodes.csv";
         MeshResponse<CheckInboxResponse> inboxResponse = MeshResponseTestHelper.CreateSuccessfulCheckInboxResponse([messageId]);
         MeshResponse<HeadMessageResponse> headResponse = MeshResponseTestHelper.CreateSuccessfulMeshHeadResponse(mailboxId, messageId, fileName, "DATA", "1:2", 2);
         MeshResponse<GetChunkedMessageResponse> messageResponse = new MeshResponse<GetChunkedMessageResponse>
@@ -326,4 +326,61 @@ public class RetrieveMeshFileTests
 
     }
 
+    [TestMethod]
+    public async Task Run_DoesNotTransferFile_IfFileNameIsInvalid()
+    {
+        //arrange
+        var messageId = "MessageId";
+        var invalidFileName = "invalid_file.csv";
+        var content = System.Text.Encoding.UTF8.GetBytes("{}");
+        MeshResponse<CheckInboxResponse> inboxResponse = MeshResponseTestHelper.CreateSuccessfulCheckInboxResponse([messageId]);
+        MeshResponse<HeadMessageResponse> headResponse = MeshResponseTestHelper.CreateSuccessfulMeshHeadResponse(mailboxId, messageId, invalidFileName);
+        MeshResponse<GetMessageResponse> messageResponse = MeshResponseTestHelper.CreateSuccessfulGetMessageResponse(mailboxId, messageId, invalidFileName, content, "application/csv");
+        MeshResponse<AcknowledgeMessageResponse> acknowledgeMessageResponse = MeshResponseTestHelper.CreateSuccessfulAcknowledgeResponse(messageId);
+
+        _mockMeshInboxService.Setup(i => i.GetMessagesAsync(mailboxId)).ReturnsAsync(inboxResponse);
+        _mockMeshInboxService.Setup(i => i.GetHeadMessageByIdAsync(mailboxId, messageId)).ReturnsAsync(headResponse);
+        _mockMeshInboxService.Setup(i => i.GetMessageByIdAsync(mailboxId, messageId)).ReturnsAsync(messageResponse);
+        _mockBlobStorageHelper.Setup(i => i.UploadFileToBlobStorage("BlobStorage_ConnectionString", "inbound", It.IsAny<BlobFile>())).ReturnsAsync(true);
+        _mockMeshInboxService.Setup(i => i.AcknowledgeMessageByIdAsync(mailboxId, messageId)).ReturnsAsync(acknowledgeMessageResponse);
+
+        //act
+        await _retrieveMeshFile.RunAsync(new Microsoft.Azure.Functions.Worker.TimerInfo());
+
+        //assert
+        _mockMeshInboxService.Verify(i => i.GetMessagesAsync(It.IsAny<string>()), Times.Once);
+        _mockMeshInboxService.Verify(i => i.GetHeadMessageByIdAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        _mockMeshInboxService.Verify(i => i.GetMessageByIdAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        _mockBlobStorageHelper.Verify(i => i.UploadFileToBlobStorage(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<BlobFile>()), Times.Never);
+        _mockMeshInboxService.Verify(i => i.AcknowledgeMessageByIdAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task Run_DoesNotTransferFile_IfFileExtensionIsInvalid()
+    {
+        //arrange
+        var messageId = "MessageId";
+        var invalidFileName = "bss_episodes.json";
+        var content = System.Text.Encoding.UTF8.GetBytes("{}");
+        MeshResponse<CheckInboxResponse> inboxResponse = MeshResponseTestHelper.CreateSuccessfulCheckInboxResponse([messageId]);
+        MeshResponse<HeadMessageResponse> headResponse = MeshResponseTestHelper.CreateSuccessfulMeshHeadResponse(mailboxId, messageId, invalidFileName);
+        MeshResponse<GetMessageResponse> messageResponse = MeshResponseTestHelper.CreateSuccessfulGetMessageResponse(mailboxId, messageId, invalidFileName, content, "application/json");
+        MeshResponse<AcknowledgeMessageResponse> acknowledgeMessageResponse = MeshResponseTestHelper.CreateSuccessfulAcknowledgeResponse(messageId);
+
+        _mockMeshInboxService.Setup(i => i.GetMessagesAsync(mailboxId)).ReturnsAsync(inboxResponse);
+        _mockMeshInboxService.Setup(i => i.GetHeadMessageByIdAsync(mailboxId, messageId)).ReturnsAsync(headResponse);
+        _mockMeshInboxService.Setup(i => i.GetMessageByIdAsync(mailboxId, messageId)).ReturnsAsync(messageResponse);
+        _mockBlobStorageHelper.Setup(i => i.UploadFileToBlobStorage("BlobStorage_ConnectionString", "inbound", It.IsAny<BlobFile>())).ReturnsAsync(true);
+        _mockMeshInboxService.Setup(i => i.AcknowledgeMessageByIdAsync(mailboxId, messageId)).ReturnsAsync(acknowledgeMessageResponse);
+
+        //act
+        await _retrieveMeshFile.RunAsync(new Microsoft.Azure.Functions.Worker.TimerInfo());
+
+        //assert
+        _mockMeshInboxService.Verify(i => i.GetMessagesAsync(It.IsAny<string>()), Times.Once);
+        _mockMeshInboxService.Verify(i => i.GetHeadMessageByIdAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        _mockMeshInboxService.Verify(i => i.GetMessageByIdAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        _mockBlobStorageHelper.Verify(i => i.UploadFileToBlobStorage(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<BlobFile>()), Times.Never);
+        _mockMeshInboxService.Verify(i => i.AcknowledgeMessageByIdAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Added file name and extension validation to the RetrieveMeshFile function. The function will now only move files from the Mesh inbox to the blob container if they meet the following requirements: 

- File extension must be .csv

- File name must start either bss_subjects or bss_episodes

Additionally, I fixed a typo in the MeshToBlobTransferHandler.

## Context

It ensures that the transfer only occurs when file names are valid. The function will transfer files that start with "bss_episodes" and "bss_subjects" and end with ".csv" from the Mesh Inbox to the blob. If they don't meet these requirements, they will remain in the inbox but will not be transferred. 

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [x] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
