### PR TITLE
refactor: create participant screening profile azure function returns bad request when nhs number is not provided

### DIFF
--- a/src/BIAnalyticsService/CreateParticipantScreeningProfile/CreateParticipantScreeningProfile.cs
+++ b/src/BIAnalyticsService/CreateParticipantScreeningProfile/CreateParticipantScreeningProfile.cs
@@ -21,7 +21,7 @@ public class CreateParticipantScreeningProfile
     [Function("CreateParticipantScreeningProfile")]
     public async Task<HttpResponseData> Run([HttpTrigger(AuthorizationLevel.Anonymous, "post")] HttpRequestData req)
     {
-        _logger.LogInformation("Create Participant Screening Profile function start,");
+        _logger.LogInformation("Create Participant Screening Profile function start");
 
         string nhsNumber = req.Query["nhs_number"];
 

--- a/src/BIAnalyticsService/CreateParticipantScreeningProfile/CreateParticipantScreeningProfile.cs
+++ b/src/BIAnalyticsService/CreateParticipantScreeningProfile/CreateParticipantScreeningProfile.cs
@@ -21,7 +21,15 @@ public class CreateParticipantScreeningProfile
     [Function("CreateParticipantScreeningProfile")]
     public async Task<HttpResponseData> Run([HttpTrigger(AuthorizationLevel.Anonymous, "post")] HttpRequestData req)
     {
-        string nhsNumber = "1111111112";
+        _logger.LogInformation("Create Participant Screening Profile function start,");
+
+        string nhsNumber = req.Query["nhs_number"];
+
+        if (string.IsNullOrEmpty(nhsNumber))
+        {
+            _logger.LogError("nhsNumber is null or empty.");
+            return req.CreateResponse(HttpStatusCode.BadRequest);
+        }
 
         var baseParticipantUrl = Environment.GetEnvironmentVariable("GetParticipantUrl");
         var participantUrl = $"{baseParticipantUrl}?nhs_number={nhsNumber}";

--- a/tests/BIAnalyticsServiceTests/CreateParticipantScreeningProfileTests/CreateParticipantScreeningProfileTests.cs
+++ b/tests/BIAnalyticsServiceTests/CreateParticipantScreeningProfileTests/CreateParticipantScreeningProfileTests.cs
@@ -32,6 +32,33 @@ public class CreateParticipantScreeningProfileTests
     }
 
     [TestMethod]
+    public async Task Run_ShouldReturnBadRequest_WhenNhsNumberIsNotProvided()
+    {
+        // Arrange
+        var queryParam = new NameValueCollection
+        {
+            { "nhs_number", null }
+        };
+
+        _mockRequest = _setupRequest.SetupGet(queryParam);
+
+        // Act
+        var response = await _function.Run(_mockRequest.Object);
+
+        // Assert
+        Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+        _mockLogger.Verify(log =>
+            log.Log(
+            LogLevel.Error,
+            0,
+            It.Is<It.IsAnyType>((state, type) => state.ToString() == "nhsNumber is null or empty."),
+            null,
+            (Func<object, Exception, string>)It.IsAny<object>()),
+            Times.Once);
+        _mockHttpRequestService.Verify(x => x.SendPost(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
     public async Task Run_ShouldReturnInternalServerError_WhenExceptionIsThrownOnCallToGetParticipant()
     {
         // Arrange


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Updated the CreateParticipantScreeningProfile.cs in the BI&Analytics service to return a BadRequest 400 when the NHS Number is not provided. I changed the hardcoded NHS Number to a query. 

Added a unit test to account for this change, testing whether the function returns a bad request when the NHS Number is not provided. 

I also ensured that the profile does not get added to the PARTICIPANT_SCREENING_PROFILE table when the NHS Number is missing. Since it's not hardcoded anymore, this should never occur

## Context

We were having a problem where, when the NHS Number was not provided in the uri, the function would still return a 200 OK and add the profile to the table. Now it will return a 400 BadRequest and will not add the profile if the NHS Number is missing.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
