### PR TITLE
fix: dtos 0000 fix pipeline trigger

### DIFF
--- a/.github/workflows/cicd-1-pull-request.yaml
+++ b/.github/workflows/cicd-1-pull-request.yaml
@@ -104,7 +104,7 @@ jobs:
     name: Image build stage
     needs: [metadata, commit-stage, test-stage]
     uses: NHSDigital/dtos-devops-templates/.github/workflows/stage-3-build-images.yaml@main
-    if: needs.metadata.outputs.does_pull_request_exist == 'true' || (github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened'))
+    if: needs.metadata.outputs.does_pull_request_exist == 'true' || github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened'))
     with:
       docker_compose_file_path: .
       environment_tag: "${{ needs.metadata.outputs.environment_tag }}"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

updated the if clause which triggers so the build image section so that it gets triggered when its on the 'main' branch. Kinda unsure why I had to do it for the SI repo but not the CM repo. 

    if: needs.metadata.outputs.does_pull_request_exist == 'true' || **github.ref == 'refs/heads/main'** || (github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened'))


<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
