### PR TITLE
fix: updating db setup to include new test data insert file path

### DIFF
--- a/scripts/database/db-setup-entrypoint.sh
+++ b/scripts/database/db-setup-entrypoint.sh
@@ -35,6 +35,6 @@ echo "Setting up the database..."
 /opt/mssql-tools/bin/sqlcmd -S "${DB_CONNECTION}" -U SA -P "${PASSWORD}" -i create_database.sql || { echo "Failed to create database"; exit 1; }
 /opt/mssql-tools/bin/sqlcmd -S "${DB_CONNECTION}" -U SA -P "${PASSWORD}" -d "${DB_NAME}" -i drop_tables.sql || { echo "Failed to drop tables"; exit 1; }
 /opt/mssql-tools/bin/sqlcmd -S "${DB_CONNECTION}" -U SA -P "${PASSWORD}" -d "${DB_NAME}" -i create_tables.sql || { echo "Failed to create tables"; exit 1; }
-/opt/mssql-tools/bin/sqlcmd -S "${DB_CONNECTION}" -U SA -P "${PASSWORD}" -d "${DB_NAME}" -i insert_episode_test_data.sql || { echo "Failed to insert test data"; exit 1; }
+/opt/mssql-tools/bin/sqlcmd -S "${DB_CONNECTION}" -U SA -P "${PASSWORD}" -d "${DB_NAME}" -i insert_test_data.sql || { echo "Failed to insert test data"; exit 1; }
 
 echo "Database setup complete."


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

PR for [DTOSS-5833](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-5833) failed to consider changes to the db-setup-entrypoint.sh. This fix ensures the file has the correct file path to the insert test data file. As it was still referring to the old one

## Context

The db-setup-entrypoint.sh still had the old file path for the insert_test_data file. 

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
