### PR TITLE
fix: dns zone changes in hub

### DIFF
--- a/infrastructure/tf-audit/locals.tf
+++ b/infrastructure/tf-audit/locals.tf
@@ -1,3 +1,0 @@
-locals {
-  primary_region = [for k, v in var.regions : k if v.is_primary_region][0]
-}

--- a/infrastructure/tf-audit/networking.tf
+++ b/infrastructure/tf-audit/networking.tf
@@ -1,3 +1,7 @@
+locals {
+  primary_region = [for k, v in var.regions : k if v.is_primary_region][0]
+}
+
 resource "azurerm_resource_group" "rg_vnet" {
   for_each = var.regions
 

--- a/infrastructure/tf-audit/private_link_scopes.tf
+++ b/infrastructure/tf-audit/private_link_scopes.tf
@@ -39,11 +39,12 @@ module "private_link_scope" {
   # Private Endpoint Configuration if enabled
   private_endpoint_properties = var.features.private_endpoints_enabled ? {
     private_dns_zone_ids = [
-      data.terraform_remote_state.hub.outputs.private_dns_zone_app_insight[each.key].private_dns_zone.id,
-      data.terraform_remote_state.hub.outputs.private_dns_zone_azure_automation[each.key].private_dns_zone.id,
-      data.terraform_remote_state.hub.outputs.private_dns_zone_od_insights[each.key].private_dns_zone.id,
-      data.terraform_remote_state.hub.outputs.private_dns_zone_op_insights[each.key].private_dns_zone.id,
-      data.terraform_remote_state.hub.outputs.private_dns_zone_storage_blob[each.key].private_dns_zone.id
+      data.terraform_remote_state.hub.outputs.private_dns_zones["${each.key}-app_insights"].id,
+      data.terraform_remote_state.hub.outputs.private_dns_zones["${each.key}-automation"].id,
+      data.terraform_remote_state.hub.outputs.private_dns_zones["${each.key}-operations_data_store"].id,
+      data.terraform_remote_state.hub.outputs.private_dns_zones["${each.key}-operations_management_suite"].id,
+      data.terraform_remote_state.hub.outputs.private_dns_zones["${each.key}-storage_blob"].id
+
     ]
     private_endpoint_enabled             = var.features.private_endpoints_enabled
     private_endpoint_subnet_id           = module.subnets["${module.regions_config[each.key].names.subnet}-pep"].id

--- a/infrastructure/tf-audit/storage.tf
+++ b/infrastructure/tf-audit/storage.tf
@@ -16,8 +16,8 @@ module "storage" {
   rbac_roles                    = local.rbac_roles_storage
   # Private Endpoint Configuration if enabled
   private_endpoint_properties = var.features.private_endpoints_enabled ? {
-    private_dns_zone_ids_blob            = [data.terraform_remote_state.hub.outputs.private_dns_zone_storage_blob[each.value.region_key].private_dns_zone.id]
-    private_dns_zone_ids_queue           = [data.terraform_remote_state.hub.outputs.private_dns_zone_storage_queue[each.value.region_key].private_dns_zone.id]
+    private_dns_zone_ids_blob            = [data.terraform_remote_state.hub.outputs.private_dns_zones["${each.value.region_key}-storage_blob"].id]
+    private_dns_zone_ids_queue           = [data.terraform_remote_state.hub.outputs.private_dns_zones["${each.value.region_key}-storage_queue"].id]
     private_endpoint_enabled             = var.features.private_endpoints_enabled
     private_endpoint_subnet_id           = module.subnets["${module.regions_config[each.value.region_key].names.subnet}-pep"].id
     private_endpoint_resource_group_name = azurerm_resource_group.rg_private_endpoints[each.value.region_key].name

--- a/infrastructure/tf-core/function_app.tf
+++ b/infrastructure/tf-core/function_app.tf
@@ -47,7 +47,7 @@ module "functionapp" {
 
   # Private Endpoint Configuration if enabled
   private_endpoint_properties = var.features.private_endpoints_enabled ? {
-    private_dns_zone_ids                 = [data.terraform_remote_state.hub.outputs.private_dns_zone_app_services[each.value.region_key].private_dns_zone.id]
+    private_dns_zone_ids                 = [data.terraform_remote_state.hub.outputs.private_dns_zones["${each.value.region_key}-app_services"].id]
     private_endpoint_enabled             = var.features.private_endpoints_enabled
     private_endpoint_subnet_id           = module.subnets["${module.regions_config[each.value.region_key].names.subnet}-pep"].id
     private_endpoint_resource_group_name = azurerm_resource_group.rg_private_endpoints[each.value.region_key].name

--- a/infrastructure/tf-core/key_vault.tf
+++ b/infrastructure/tf-core/key_vault.tf
@@ -18,7 +18,7 @@ module "key_vault" {
 
   # Private Endpoint Configuration if enabled
   private_endpoint_properties = var.features.private_endpoints_enabled ? {
-    private_dns_zone_ids_keyvault        = [data.terraform_remote_state.hub.outputs.private_dns_zone_key_vault[each.key].private_dns_zone.id]
+    private_dns_zone_ids_keyvault        = [data.terraform_remote_state.hub.outputs.private_dns_zones["${each.key}-key_vault"].id]
     private_endpoint_enabled             = var.features.private_endpoints_enabled
     private_endpoint_subnet_id           = module.subnets["${module.regions_config[each.key].names.subnet}-pep"].id
     private_endpoint_resource_group_name = azurerm_resource_group.rg_private_endpoints[each.key].name

--- a/infrastructure/tf-core/rbac.tf
+++ b/infrastructure/tf-core/rbac.tf
@@ -14,4 +14,10 @@ locals {
   rbac_roles_database = {
     sql_contributor = "Contributor"
   }
+
+  rbac_roles_key_vault_officers = [
+    "Key Vault Certificate Officer",
+    "Key Vault Crypto Officer",
+    "Key Vault Secrets Officer"
+  ]
 }

--- a/infrastructure/tf-core/sql_server.tf
+++ b/infrastructure/tf-core/sql_server.tf
@@ -44,7 +44,7 @@ module "azure_sql_server" {
 
   # Private Endpoint Configuration if enabled
   private_endpoint_properties = var.features.private_endpoints_enabled ? {
-    private_dns_zone_ids_sql             = [data.terraform_remote_state.hub.outputs.private_dns_zone_azure_sql[each.key].private_dns_zone.id]
+    private_dns_zone_ids_sql             = [data.terraform_remote_state.hub.outputs.private_dns_zones["${each.key}-azure_sql"].id]
     private_endpoint_enabled             = var.features.private_endpoints_enabled
     private_endpoint_subnet_id           = module.subnets["${module.regions_config[each.key].names.subnet}-pep"].id
     private_endpoint_resource_group_name = azurerm_resource_group.rg_private_endpoints[each.key].name

--- a/infrastructure/tf-core/storage.tf
+++ b/infrastructure/tf-core/storage.tf
@@ -20,8 +20,8 @@ module "storage" {
 
   # Private Endpoint Configuration if enabled
   private_endpoint_properties = var.features.private_endpoints_enabled ? {
-    private_dns_zone_ids_blob            = [data.terraform_remote_state.hub.outputs.private_dns_zone_storage_blob[each.value.region_key].private_dns_zone.id]
-    private_dns_zone_ids_queue           = [data.terraform_remote_state.hub.outputs.private_dns_zone_storage_queue[each.value.region_key].private_dns_zone.id]
+    private_dns_zone_ids_blob            = [data.terraform_remote_state.hub.outputs.private_dns_zones["${each.value.region_key}-storage_blob"].id]
+    private_dns_zone_ids_queue           = [data.terraform_remote_state.hub.outputs.private_dns_zones["${each.value.region_key}-storage_queue"].id]
     private_endpoint_enabled             = var.features.private_endpoints_enabled
     private_endpoint_subnet_id           = module.subnets["${module.regions_config[each.value.region_key].names.subnet}-pep"].id
     private_endpoint_resource_group_name = azurerm_resource_group.rg_private_endpoints[each.value.region_key].name


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This is to update the fact that we have cleaned up the way we generate the private DNS zones within the dtos-hub repo. We now have a single module call that is looped around rather than having 10 individual module calls.  

rivate_dns_zone_ids_sql             = [data.terraform_remote_state.hub.outputs.private_dns_zones["${each.key}-azure_sql"].id]

This has been deployed in both NFT and Dev pipelines: - 

https://dev.azure.com/nhse-dtos/dtos-service-insights/_build/results?buildId=8913&view=results

https://dev.azure.com/nhse-dtos/dtos-service-insights/_build/results?buildId=8914&view=results


<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
