### PR TITLE
feat: Make the Create Participant Screening Profile function event driven

### DIFF
--- a/compose-win.yaml
+++ b/compose-win.yaml
@@ -151,7 +151,6 @@ services:
       - ASPNETCORE_ENVIRONMENT=Development
       - FUNCTIONS_WORKER_RUNTIME=dotnet-isolated
       - ASPNETCORE_URLS=http://*:6009
-      - GetParticipantUrl=http://127.0.0.1:6061/api/GetParticipant
       - CreateParticipantScreeningProfileUrl=http://127.0.0.1:6011/api/CreateParticipantScreeningProfile
       - DemographicsServiceUrl=http://127.0.0.1:6080/api/GetDemographicsData
       - GetScreeningDataUrl=http://127.0.0.1:6082/api/GetScreeningData

--- a/compose.yaml
+++ b/compose.yaml
@@ -172,7 +172,6 @@ services:
       - ASPNETCORE_ENVIRONMENT=Development
       - FUNCTIONS_WORKER_RUNTIME=dotnet-isolated
       - ASPNETCORE_URLS=http://*:6009
-      - GetParticipantUrl=http://get-participant:6061/api/GetParticipant
       - CreateParticipantScreeningProfileUrl=http://create-ps-profile-data:6011/api/CreateParticipantScreeningProfile
       - DemographicsServiceUrl=http://get-demographics-data:6080/api/GetDemographicsData
       - GetScreeningDataUrl=http://get-screening-data:6082/api/GetScreeningData

--- a/src/BIAnalyticsManagementService/CreateParticipantScreeningProfile/CreateParticipantScreeningProfile.cs
+++ b/src/BIAnalyticsManagementService/CreateParticipantScreeningProfile/CreateParticipantScreeningProfile.cs
@@ -1,8 +1,7 @@
-using System.Net;
 using Microsoft.Azure.Functions.Worker;
-using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 using System.Text.Json;
+using Azure.Messaging.EventGrid;
 using NHS.ServiceInsights.Common;
 using NHS.ServiceInsights.Model;
 
@@ -18,44 +17,25 @@ public class CreateParticipantScreeningProfile
         _httpRequestService = httpRequestService;
     }
 
-    [Function("CreateParticipantScreeningProfile")]
-    public async Task<HttpResponseData> Run([HttpTrigger(AuthorizationLevel.Anonymous, "post")] HttpRequestData req)
+    [Function(nameof(CreateParticipantScreeningProfile))]
+    public async Task Run([EventGridTrigger] EventGridEvent eventGridEvent)
     {
         _logger.LogInformation("Create Participant Screening Profile function start");
 
-        string nhsNumber = req.Query["nhs_number"];
-
-        if (string.IsNullOrEmpty(nhsNumber))
-        {
-            _logger.LogError("nhsNumber is null or empty.");
-            return req.CreateResponse(HttpStatusCode.BadRequest);
-        }
-
-        var baseParticipantUrl = Environment.GetEnvironmentVariable("GetParticipantUrl");
-        var participantUrl = $"{baseParticipantUrl}?nhs_number={nhsNumber}";
-        _logger.LogInformation("Requesting participant URL: {Url}", participantUrl);
+        string serializedEvent = JsonSerializer.Serialize(eventGridEvent);
+        _logger.LogInformation(serializedEvent);
 
         ParticipantDto participant;
 
         try
         {
-            var participantResponse = await _httpRequestService.SendGet(participantUrl);
-
-            if (!participantResponse.IsSuccessStatusCode)
-            {
-                _logger.LogError("Failed to retrieve participant data with NHS number {NhsNumber}. Status Code: {StatusCode}", nhsNumber, participantResponse.StatusCode);
-                return req.CreateResponse(HttpStatusCode.InternalServerError);
-            }
-
-            var participantJson = await participantResponse.Content.ReadAsStringAsync();
-            participant = JsonSerializer.Deserialize<ParticipantDto>(participantJson);
-            _logger.LogInformation("Participant data retrieved and deserialised");
+            participant = JsonSerializer.Deserialize<ParticipantDto>(eventGridEvent.Data.ToString());
         }
 
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to deserialise or retrieve participant from {participantUrl}.", participantUrl);
-            return req.CreateResponse(HttpStatusCode.InternalServerError);
+            _logger.LogError(ex, "Unable to deserialize event data to Participant object.");
+            return;
         }
 
         try
@@ -66,16 +46,13 @@ public class CreateParticipantScreeningProfile
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to create participant screening profile.");
-            return req.CreateResponse(HttpStatusCode.InternalServerError);
         }
-
-        return req.CreateResponse(HttpStatusCode.OK);
     }
 
-    private async Task<DemographicsData> GetDemographicsDataAsync(long nhsNumber)
+    private async Task<DemographicsData> GetDemographicsDataAsync(long NhsNumber)
     {
         var baseDemographicsServiceUrl = Environment.GetEnvironmentVariable("DemographicsServiceUrl");
-        var demographicsServiceUrl = $"{baseDemographicsServiceUrl}?nhs_number={nhsNumber}";
+        var demographicsServiceUrl = $"{baseDemographicsServiceUrl}?nhs_number={NhsNumber}";
         _logger.LogInformation("Requesting demographic service URL: {Url}", demographicsServiceUrl);
 
         DemographicsData demographicsData;
@@ -90,10 +67,10 @@ public class CreateParticipantScreeningProfile
         return demographicsData;
     }
 
-    private async Task<ScreeningLkp> GetScreeningDataAsync(long screening_id)
+    private async Task<ScreeningLkp> GetScreeningDataAsync(long ScreeningId)
     {
         var baseScreeningDataServiceUrl = Environment.GetEnvironmentVariable("GetScreeningDataUrl");
-        var getScreeningDataUrl = $"{baseScreeningDataServiceUrl}?screening_id={screening_id}";
+        var getScreeningDataUrl = $"{baseScreeningDataServiceUrl}?screening_id={ScreeningId}";
         _logger.LogInformation("Requesting screening data from {Url}", getScreeningDataUrl);
 
         ScreeningLkp screeningLkp;

--- a/src/BIAnalyticsManagementService/CreateParticipantScreeningProfile/CreateParticipantScreeningProfile.cs
+++ b/src/BIAnalyticsManagementService/CreateParticipantScreeningProfile/CreateParticipantScreeningProfile.cs
@@ -49,10 +49,10 @@ public class CreateParticipantScreeningProfile
         }
     }
 
-    private async Task<DemographicsData> GetDemographicsDataAsync(long NhsNumber)
+    private async Task<DemographicsData> GetDemographicsDataAsync(long nhsNumber)
     {
         var baseDemographicsServiceUrl = Environment.GetEnvironmentVariable("DemographicsServiceUrl");
-        var demographicsServiceUrl = $"{baseDemographicsServiceUrl}?nhs_number={NhsNumber}";
+        var demographicsServiceUrl = $"{baseDemographicsServiceUrl}?nhs_number={nhsNumber}";
         _logger.LogInformation("Requesting demographic service URL: {Url}", demographicsServiceUrl);
 
         DemographicsData demographicsData;
@@ -67,10 +67,10 @@ public class CreateParticipantScreeningProfile
         return demographicsData;
     }
 
-    private async Task<ScreeningLkp> GetScreeningDataAsync(long ScreeningId)
+    private async Task<ScreeningLkp> GetScreeningDataAsync(long screeningId)
     {
         var baseScreeningDataServiceUrl = Environment.GetEnvironmentVariable("GetScreeningDataUrl");
-        var getScreeningDataUrl = $"{baseScreeningDataServiceUrl}?screening_id={ScreeningId}";
+        var getScreeningDataUrl = $"{baseScreeningDataServiceUrl}?screening_id={screeningId}";
         _logger.LogInformation("Requesting screening data from {Url}", getScreeningDataUrl);
 
         ScreeningLkp screeningLkp;

--- a/src/BIAnalyticsManagementService/CreateParticipantScreeningProfile/CreateParticipantScreeningProfile.csproj
+++ b/src/BIAnalyticsManagementService/CreateParticipantScreeningProfile/CreateParticipantScreeningProfile.csproj
@@ -10,8 +10,9 @@
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.19.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.15.1" />
+    <PackageReference Include="Azure.Messaging.EventGrid" Version="4.28.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.EventGrid" Version="3.4.2" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/src/BIAnalyticsManagementService/CreateParticipantScreeningProfile/local.settings.json.template
+++ b/src/BIAnalyticsManagementService/CreateParticipantScreeningProfile/local.settings.json.template
@@ -4,7 +4,6 @@
     "ASPNETCORE_ENVIRONMENT": "Development",
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-    "GetParticipantUrl": "http://localhost:6061/api/GetParticipant",
     "CreateParticipantScreeningProfileUrl":"http://localhost:6011/api/CreateParticipantScreeningProfile",
     "DemographicsServiceUrl": "http://localhost:6080/api/GetDemographicsData",
     "GetScreeningDataUrl": "http://localhost:6082/api/GetScreeningData"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

I made the Create Participant Screening Profile function event driven. This change was actioned on the Create Participant Screening Episode function last week, and now this one is too. The changes to the function itself are limited. I removed the call to Get Participant and imported the Event Grid. 

Made changes to the unit test to account for these updates.

## Context

The BI&Analytics Service is supposed to be event-driven. 

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
