### PR TITLE
feat: Create finalised Participant dto that includes reference data

### DIFF
--- a/infrastructure/tf-core/environments/int.tfvars
+++ b/infrastructure/tf-core/environments/int.tfvars
@@ -280,10 +280,10 @@ function_apps = {
     }
 
     CreateEpisode = {
-      name_suffix            = "create-episode"
-      function_endpoint_name = "CreateEpisode"
-      app_service_plan_key   = "BIAnalyticsDataService"
-      db_connection_string   = "ServiceInsightsDbConnectionString"
+      name_suffix               = "create-episode"
+      function_endpoint_name    = "CreateEpisode"
+      app_service_plan_key      = "BIAnalyticsDataService"
+      db_connection_string      = "ServiceInsightsDbConnectionString"
       event_grid_topic_producer = "topic-int-1"
     }
 
@@ -295,10 +295,10 @@ function_apps = {
     }
 
     UpdateEpisode = {
-      name_suffix            = "update-episode"
-      function_endpoint_name = "UpdateEpisode"
-      app_service_plan_key   = "BIAnalyticsDataService"
-      db_connection_string   = "ServiceInsightsDbConnectionString"
+      name_suffix               = "update-episode"
+      function_endpoint_name    = "UpdateEpisode"
+      app_service_plan_key      = "BIAnalyticsDataService"
+      db_connection_string      = "ServiceInsightsDbConnectionString"
       event_grid_topic_producer = "topic-int-1"
     }
 

--- a/src/BIAnalyticsManagementService/CreateParticipantScreeningProfile/CreateParticipantScreeningProfile.cs
+++ b/src/BIAnalyticsManagementService/CreateParticipantScreeningProfile/CreateParticipantScreeningProfile.cs
@@ -25,11 +25,11 @@ public class CreateParticipantScreeningProfile
         string serializedEvent = JsonSerializer.Serialize(eventGridEvent);
         _logger.LogInformation(serializedEvent);
 
-        ParticipantDto participant;
+        FinalizedParticipantDto participant;
 
         try
         {
-            participant = JsonSerializer.Deserialize<ParticipantDto>(eventGridEvent.Data.ToString());
+            participant = JsonSerializer.Deserialize<FinalizedParticipantDto>(eventGridEvent.Data.ToString());
         }
 
         catch (Exception ex)
@@ -86,7 +86,7 @@ public class CreateParticipantScreeningProfile
         return screeningLkp;
     }
 
-    private async Task SendToCreateParticipantScreeningProfileAsync(ParticipantDto participant)
+    private async Task SendToCreateParticipantScreeningProfileAsync(FinalizedParticipantDto participant)
     {
         DemographicsData demographicsData = await GetDemographicsDataAsync(participant.NhsNumber);
         ScreeningLkp screeningLkp = await GetScreeningDataAsync(participant.ScreeningId);
@@ -97,8 +97,8 @@ public class CreateParticipantScreeningProfile
             ScreeningName = screeningLkp.ScreeningName,
             PrimaryCareProvider = demographicsData.PrimaryCareProvider,
             PreferredLanguage = demographicsData.PreferredLanguage,
-            ReasonForRemoval = String.Empty,
-            ReasonForRemovalDt = new DateOnly(),
+            ReasonForRemoval = participant.ReasonForRemoval,
+            ReasonForRemovalDt = participant.ReasonForRemovalDt,
             NextTestDueDate = participant.NextTestDueDate,
             NextTestDueDateCalcMethod = participant.NextTestDueDateCalculationMethod,
             ParticipantScreeningStatus = participant.ParticipantScreeningStatus,
@@ -107,10 +107,10 @@ public class CreateParticipantScreeningProfile
             IsHigherRiskActive = participant.IsHigherRiskActive,
             HigherRiskNextTestDueDate = participant.HigherRiskNextTestDueDate,
             HigherRiskReferralReasonCode = participant.HigherRiskReferralReasonCode,
-            HrReasonCodeDescription = String.Empty,
+            HrReasonCodeDescription = participant.HigherRiskReasonCodeDescription,
             DateIrradiated = participant.DateIrradiated,
             GeneCode = participant.GeneCode,
-            GeneCodeDescription = String.Empty,
+            GeneCodeDescription = participant.GeneDescription,
             RecordInsertDatetime = DateTime.Now
         };
 

--- a/src/EpisodeIntegrationService/ReceiveData/ReceiveData.cs
+++ b/src/EpisodeIntegrationService/ReceiveData/ReceiveData.cs
@@ -237,9 +237,9 @@ public class ReceiveData
             await ProcessParticipantDataAsync(name,subjects, participantUrl);
         }
     }
-    private ParticipantDto MapParticipantToParticipantDto(BssSubject subject)
+    private InitialParticipantDto MapParticipantToParticipantDto(BssSubject subject)
     {
-        return new ParticipantDto
+        return new InitialParticipantDto
         {
             NhsNumber = subject.nhs_number,
             ScreeningName = "Breast Screening",

--- a/src/ParticipantManagementService/GetParticipant/ParticipantRepository.cs
+++ b/src/ParticipantManagementService/GetParticipant/ParticipantRepository.cs
@@ -4,19 +4,19 @@ namespace NHS.ServiceInsights.ParticipantManagementService;
 
 public static class ParticipantRepository
 {
-    private static readonly List<ParticipantDto> Participants = new List<ParticipantDto>
+    private static readonly List<InitialParticipantDto> Participants = new List<InitialParticipantDto>
     {
 
-        new ParticipantDto { NhsNumber = 1111111112, ScreeningName = "Breast Screening", ScreeningId = 1, NextTestDueDate = new DateOnly(2019, 08, 01), NextTestDueDateCalculationMethod = "ROUTINE", ParticipantScreeningStatus = "NORMAL",
+        new InitialParticipantDto { NhsNumber = 1111111112, ScreeningName = "Breast Screening", ScreeningId = 1, NextTestDueDate = new DateOnly(2019, 08, 01), NextTestDueDateCalculationMethod = "ROUTINE", ParticipantScreeningStatus = "NORMAL",
                         ScreeningCeasedReason = "PERSONAL_WELFARE",  IsHigherRisk = 1, IsHigherRiskActive = 1, HigherRiskNextTestDueDate = new DateOnly(2020, 02, 01), HigherRiskReferralReasonCode = "", DateIrradiated = new DateOnly(2019, 12, 01),
                         GeneCode = "BRCA1"},
 
-        new ParticipantDto { NhsNumber = 1111111110, ScreeningName = "Breast Screening", ScreeningId = 2, NextTestDueDate = new DateOnly(2019, 08, 01), NextTestDueDateCalculationMethod = "ROUTINE", ParticipantScreeningStatus = "NORMAL",
+        new InitialParticipantDto { NhsNumber = 1111111110, ScreeningName = "Breast Screening", ScreeningId = 2, NextTestDueDate = new DateOnly(2019, 08, 01), NextTestDueDateCalculationMethod = "ROUTINE", ParticipantScreeningStatus = "NORMAL",
                         ScreeningCeasedReason = "PERSONAL_WELFARE",  IsHigherRisk = 1, IsHigherRiskActive = 0, HigherRiskNextTestDueDate = null, HigherRiskReferralReasonCode = "OTHER_GENE_MUTATIONS", DateIrradiated = new DateOnly(2019, 08, 01),
                         GeneCode = "STK11"},
     };
 
-    public static ParticipantDto GetParticipantByNhsNumber(long NhsNumber)
+    public static InitialParticipantDto GetParticipantByNhsNumber(long NhsNumber)
     {
         return Participants.Find(p => p.NhsNumber == NhsNumber);
     }

--- a/src/ParticipantManagementService/UpdateParticipant/UpdateParticipant.cs
+++ b/src/ParticipantManagementService/UpdateParticipant/UpdateParticipant.cs
@@ -27,7 +27,7 @@ public class UpdateParticipant
             using (StreamReader reader = new StreamReader(req.Body, Encoding.UTF8))
             {
                 var postData = await reader.ReadToEndAsync();
-                JsonSerializer.Deserialize<ParticipantDto>(postData);
+                JsonSerializer.Deserialize<InitialParticipantDto>(postData);
                 _logger.LogInformation("PostData: {postData}", postData);
             }
 

--- a/src/Shared/Model/Dtos/FinalizedParticipantDto.cs
+++ b/src/Shared/Model/Dtos/FinalizedParticipantDto.cs
@@ -1,0 +1,21 @@
+namespace NHS.ServiceInsights.Model;
+public class FinalizedParticipantDto
+{
+    public long NhsNumber { get; set; }
+    public long ScreeningId { get; set; }
+    public string? ReasonForRemoval { get; set; }
+    public DateOnly? ReasonForRemovalDt { get; set; }
+    public DateOnly? NextTestDueDate { get; set; }
+    public string? NextTestDueDateCalculationMethod { get; set; }
+    public string? ParticipantScreeningStatus { get; set; }
+    public string? ScreeningCeasedReason { get; set; }
+    public short? IsHigherRisk { get; set; }
+    public short? IsHigherRiskActive { get; set; }
+    public DateTime SrcSysProcessedDateTime { get; set; }
+    public DateOnly? HigherRiskNextTestDueDate { get; set; }
+    public string? HigherRiskReferralReasonCode { get; set; }
+    public string? HigherRiskReasonCodeDescription { get; set; }
+    public DateOnly? DateIrradiated { get; set; }
+    public string? GeneCode { get; set; }
+    public string? GeneDescription { get; set; }
+}

--- a/src/Shared/Model/Dtos/InitialParticipantDto.cs
+++ b/src/Shared/Model/Dtos/InitialParticipantDto.cs
@@ -1,5 +1,5 @@
 namespace NHS.ServiceInsights.Model;
-public class ParticipantDto
+public class InitialParticipantDto
 {
     public long NhsNumber { get; set; }
     public string ScreeningName { get; set; }

--- a/tests/EpisodeIntegrationServiceTests/ReceiveDataTests/ReceiveDataTests.cs
+++ b/tests/EpisodeIntegrationServiceTests/ReceiveDataTests/ReceiveDataTests.cs
@@ -322,7 +322,7 @@ public class ReceiveDataTests
                 "2020-03-31 12:49:47.513821+01,9000009808,,A00009,LAV,2019-09-05,NORMAL,,2016-09-05,,,INFORMED_SUBJECT_CHOICE,True,2019-09-05,,BRCA_RISK,2021-09-05,True,BRCA1,ROUTINE,\n";
 
         var stream = new MemoryStream(Encoding.UTF8.GetBytes(data));
-        var expectedParticipantDto = new ParticipantDto
+        var expectedParticipantDto = new InitialParticipantDto
         {
             NhsNumber = 9000009808,
             SrcSysProcessedDateTime = DateTime.Parse("2020-03-31 12:49:47.513821+01"),

--- a/tests/ParticipantManagementServiceTests/GetParticipantTests/GetParticipantTests.cs
+++ b/tests/ParticipantManagementServiceTests/GetParticipantTests/GetParticipantTests.cs
@@ -98,12 +98,12 @@ public class GetParticipantTests
 
         // Assert
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-        ParticipantDto participant;
+        InitialParticipantDto participant;
         using (StreamReader reader = new StreamReader(response.Body, Encoding.UTF8))
         {
             response.Body.Seek(0, SeekOrigin.Begin);
             var responseBody = reader.ReadToEnd();
-            participant = JsonSerializer.Deserialize<ParticipantDto>(responseBody);
+            participant = JsonSerializer.Deserialize<InitialParticipantDto>(responseBody);
         }
         Assert.AreEqual(1111111110, participant.NhsNumber);
     }

--- a/tests/ParticipantManagementServiceTests/UpdateParticipantTests/UpdateParticipantTests.cs
+++ b/tests/ParticipantManagementServiceTests/UpdateParticipantTests/UpdateParticipantTests.cs
@@ -41,7 +41,7 @@ public class UpdateParticipantTests
     public async Task Run_ShouldReturnOK_WhenValidParticipantReceived()
     {
         // Arrange
-        var participant = new ParticipantDto
+        var participant = new InitialParticipantDto
         {
             NhsNumber = 999999999
         };


### PR DESCRIPTION

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Created a FinalizedParticipantDto that includes reference data. This is used for the mapping in CreateParticipantScreeningProfile (ManagementService) rather than using the now renamed InitialParticipantDto that was missing reference data to be used to map to the Participant Screening Profile table in the aforementioned function. 
Updated ReceiveData to reflect name change

## Context

It ensures that the Participant Screening Profile table has the right reference data and gets it from the right place. These columns were previously empty.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [x] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
