### PR TITLE
fix: ensure file extension assertion before processing

### DIFF
--- a/infrastructure/tf-core/environments/development.tfvars
+++ b/infrastructure/tf-core/environments/development.tfvars
@@ -360,7 +360,7 @@ function_apps = {
       app_service_plan_key   = "Default"
       key_vault_url          = "KeyVaultConnectionString"
       env_vars_static = {
-        TimerExpression  = "*/5 * * * *"
+        TimerExpression = "*/5 * * * *"
       }
     }
 

--- a/infrastructure/tf-core/environments/int.tfvars
+++ b/infrastructure/tf-core/environments/int.tfvars
@@ -356,7 +356,7 @@ function_apps = {
       app_service_plan_key   = "BIAnalyticsDataService"
       key_vault_url          = "KeyVaultConnectionString"
       env_vars_static = {
-        TimerExpression  = "*/5 * * * *"
+        TimerExpression = "*/5 * * * *"
       }
     }
 

--- a/infrastructure/tf-core/environments/nft.tfvars
+++ b/infrastructure/tf-core/environments/nft.tfvars
@@ -353,7 +353,7 @@ function_apps = {
       app_service_plan_key   = "BIAnalyticsDataService"
       key_vault_url          = "KeyVaultConnectionString"
       env_vars_static = {
-        TimerExpression  = "*/5 * * * *"
+        TimerExpression = "*/5 * * * *"
       }
     }
 

--- a/src/EpisodeIntegrationService/ReceiveData/ReceiveData.cs
+++ b/src/EpisodeIntegrationService/ReceiveData/ReceiveData.cs
@@ -39,6 +39,12 @@ public class ReceiveData
 
             _logger.LogInformation("C# HTTP trigger function ReceiveData received a request.");
 
+            if (!name.EndsWith(".csv", StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogError("Invalid file extension. Only .csv files are supported.");
+                return;
+            }
+
             var (episodeUrl, participantUrl) = GetConfigurationUrls();
             if (string.IsNullOrEmpty(episodeUrl) || string.IsNullOrEmpty(participantUrl))
             {

--- a/tests/EpisodeIntegrationServiceTests/ReceiveDataTests/ReceiveDataTests.cs
+++ b/tests/EpisodeIntegrationServiceTests/ReceiveDataTests/ReceiveDataTests.cs
@@ -38,7 +38,7 @@ public class ReceiveDataTests
         var stream = new MemoryStream(Encoding.UTF8.GetBytes(data));
 
         // Act
-        await _function.Run(stream, "bss_episodes_test_data_20240930");
+        await _function.Run(stream, "bss_episodes_test_data_20240930.csv");
 
         // Assert -- verify the counters of Rows
         var expectedLogMessages = new List<string>
@@ -102,7 +102,7 @@ public class ReceiveDataTests
         var expectedJson = JsonSerializer.Serialize(expectedEpisodeDto);
 
         // Act
-        await _function.Run(stream, "bss_episodes_test_data_20240930");
+        await _function.Run(stream, "bss_episodes_test_data_20240930.csv");
 
         // Assert
         _mockHttpRequestService.Verify(x => x.SendPost("EpisodeManagementUrl", It.Is<string>(x => x == expectedJson)), Times.Once);
@@ -124,7 +124,7 @@ public class ReceiveDataTests
         var stream = new MemoryStream(Encoding.UTF8.GetBytes(data));
 
         // Act
-        await _function.Run(stream, "bss_episodes_test_data_20240930");
+        await _function.Run(stream, "bss_episodes_test_data_20240930.csv");
 
         // Assert
         _mockHttpRequestService.Verify(x => x.SendPost("EpisodeManagementUrl", It.IsAny<string>()), Times.Exactly(6));
@@ -147,7 +147,7 @@ public class ReceiveDataTests
         var stream = new MemoryStream(Encoding.UTF8.GetBytes(data));
 
         // Act
-        await _function.Run(stream, "bss_episodes_test_data_20240930");
+        await _function.Run(stream, "bss_episodes_test_data_20240930.csv");
 
         // Assert
         _mockHttpRequestService.Verify(x => x.SendPost("EpisodeManagementUrl", It.IsAny<string>()), Times.Exactly(6));
@@ -171,7 +171,7 @@ public class ReceiveDataTests
         var stream = new MemoryStream(Encoding.UTF8.GetBytes(data));
 
         // Act
-        await _function.Run(stream, "bss_episodes_test_data_20240930");
+        await _function.Run(stream, "bss_episodes_test_data_20240930.csv");
 
         // Assert
         _mockHttpRequestService.Verify(x => x.SendPost("EpisodeManagementUrl", It.IsAny<string>()), Times.Exactly(6));
@@ -195,7 +195,7 @@ public class ReceiveDataTests
         var stream = new MemoryStream(Encoding.UTF8.GetBytes(data));
 
         // Act
-        await _function.Run(stream, "bss_episodes_test_data_20240930");
+        await _function.Run(stream, "bss_episodes_test_data_20240930.csv");
 
         // Assert
         _mockHttpRequestService.Verify(x => x.SendPost("EpisodeManagementUrl", It.IsAny<string>()), Times.Exactly(6));
@@ -215,7 +215,7 @@ public class ReceiveDataTests
         var stream = new MemoryStream(Encoding.UTF8.GetBytes(data));
 
         // Act
-        await _function.Run(stream, "bss_episodes_test_data_20240930");
+        await _function.Run(stream, "bss_episodes_test_data_20240930.csv");
 
         // Assert
         _mockLogger.Verify(log =>
@@ -241,7 +241,7 @@ public class ReceiveDataTests
         var stream = new MemoryStream(Encoding.UTF8.GetBytes(data));
 
         // Act
-        await _function.Run(stream, "bss_subjects_test_data_20240930");
+        await _function.Run(stream, "bss_subjects_test_data_20240930.csv");
 
         // Assert -- verify the counters of Rows
         var expectedLogMessages = new List<string>
@@ -284,7 +284,7 @@ public class ReceiveDataTests
         var stream = new MemoryStream(Encoding.UTF8.GetBytes(data));
 
         // Act
-        await _function.Run(stream, "bss_subjects_test_data_20240930");
+        await _function.Run(stream, "bss_subjects_test_data_20240930.csv");
 
         // Assert -- verify the counters of Rows
         var expectedLogMessages = new List<string>
@@ -341,7 +341,7 @@ public class ReceiveDataTests
         var expectedJson = JsonSerializer.Serialize(expectedParticipantDto);
 
         // Act
-        await _function.Run(stream, "bss_subjects_test_data_20240930");
+        await _function.Run(stream, "bss_subjects_test_data_20240930.csv");
 
         // Assert
         _mockHttpRequestService.Verify(x => x.SendPost("ParticipantManagementUrl", It.Is<string>(x => x == expectedJson)), Times.Once);
@@ -361,7 +361,7 @@ public class ReceiveDataTests
         var stream = new MemoryStream(Encoding.UTF8.GetBytes(data));
 
         // Act
-        await _function.Run(stream, "bss_episodes_test_data_20240930");
+        await _function.Run(stream, "bss_episodes_test_data_20240930.csv");
 
         // Assert -- verify the counters of Rows
         var expectedLogMessages = new List<string>
@@ -405,7 +405,7 @@ public class ReceiveDataTests
         var stream = new MemoryStream(Encoding.UTF8.GetBytes(data));
 
         // Act
-        await _function.Run(stream, "bss_subjects_test_data_20240930");
+        await _function.Run(stream, "bss_subjects_test_data_20240930.csv");
 
         // Assert
         _mockLogger.Verify(log =>
@@ -434,7 +434,7 @@ public class ReceiveDataTests
         var stream = new MemoryStream(Encoding.UTF8.GetBytes(data));
 
         // Act
-        await _function.Run(stream, "invalid_file_name");
+        await _function.Run(stream, "invalid_file_name.csv");
 
         // Assert
         _mockLogger.Verify(log =>
@@ -459,7 +459,7 @@ public class ReceiveDataTests
         var stream = new MemoryStream(Encoding.UTF8.GetBytes(data));
 
         // Act
-        await _function.Run(stream, "bss_episodes_test_data_20240930");
+        await _function.Run(stream, "bss_episodes_test_data_20240930.csv");
 
         // Assert
         _mockHttpRequestService.Verify(x => x.SendPost("EpisodeManagementUrl", It.IsAny<string>()), Times.Exactly(0));
@@ -487,7 +487,7 @@ public class ReceiveDataTests
         var stream = new MemoryStream(Encoding.UTF8.GetBytes(data));
 
         // Act
-        await _function.Run(stream, "bss_subjects_test_data_20240930");
+        await _function.Run(stream, "bss_subjects_test_data_20240930.csv");
 
         // Assert
         _mockHttpRequestService.Verify(x => x.SendPost("EpisodeManagementUrl", It.IsAny<string>()), Times.Exactly(0));
@@ -522,7 +522,7 @@ public class ReceiveDataTests
         var stream = new MemoryStream(Encoding.UTF8.GetBytes(data));
 
         // Act
-        await _function.Run(stream, "bss_episodes_test_data_20240930");
+        await _function.Run(stream, "bss_episodes_test_data_20240930.csv");
 
         // Assert
         _mockHttpRequestService.Verify(x => x.SendPost("EpisodeManagementUrl", It.IsAny<string>()), Times.Exactly(6));
@@ -544,7 +544,7 @@ public class ReceiveDataTests
         var stream = new MemoryStream(Encoding.UTF8.GetBytes(data));
 
         // Act
-        await _function.Run(stream, "bss_subjects_test_data_20240930");
+        await _function.Run(stream, "bss_subjects_test_data_20240930.csv");
 
         // Assert
         _mockHttpRequestService.Verify(x => x.SendPost("EpisodeManagementUrl", It.IsAny<string>()), Times.Exactly(0));
@@ -564,7 +564,7 @@ public class ReceiveDataTests
         Environment.SetEnvironmentVariable("ParticipantManagementUrl", "");
 
         // Act
-        await _function.Run(stream, "bss_episodes_test_data_20240930");
+        await _function.Run(stream, "bss_episodes_test_data_20240930.csv");
 
         // Assert
         _mockLogger.Verify(log =>
@@ -576,6 +576,34 @@ public class ReceiveDataTests
             (Func<object, Exception, string>)It.IsAny<object>()),
             Times.Once);
     }
+
+
+    [TestMethod]
+    public async Task ReceiveData_ShouldLogErrorAndReturnIfFileExtensionIsNotCsv()
+    {
+        // Arrange
+        string data = "nhs_number,episode_id,episode_type,change_db_date_time,episode_date,appointment_made,date_of_foa,date_of_as,early_recall_date,call_recall_status_authorised_by,end_code,end_code_last_updated,bso_organisation_code,bso_batch_id,reason_closed_code,end_point,final_action_code\n" +
+                    "9000007053,571645,R,2020-03-31 12:11:47.339148+01,2017-01-11,True,,,,SCREENING_OFFICE,SC,2020-03-31 00:00:00+01,LAV,LAV121798J,,,\n" +
+                    "9000009808,333330,R,2020-03-31 12:49:47.513821+01,2016-09-05,True,,,,SCREENING_OFFICE,SC,2020-03-31 00:00:00+01,LAV,LAV000001A,,,\n";
+
+        var stream = new MemoryStream(Encoding.UTF8.GetBytes(data));
+
+        // Act
+        await _function.Run(stream, "bss_episodes_test_data_20240930.txt");
+
+        // Assert
+        _mockLogger.Verify(log =>
+            log.Log(
+            LogLevel.Error,
+            0,
+            It.Is<object>(state => state.ToString().Contains("Invalid file extension. Only .csv files are supported.")),
+            It.IsAny<Exception>(),
+            (Func<object, Exception, string>)It.IsAny<object>()),
+            Times.Exactly(1));
+
+        _mockHttpRequestService.Verify(x => x.SendPost(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
 
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- Update ReceiveData function to ensure file extension assertion before processing
- Update ReceiveDatatests 

## Context

https://nhsd-jira.digital.nhs.uk/browse/DTOSS-6463

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
