### PR TITLE
Fix : display file name when schema validation fails and make episode_type and episode_date mandatory 

### DIFF
--- a/src/EpisodeIntegrationService/ReceiveData/BssEpisode.cs
+++ b/src/EpisodeIntegrationService/ReceiveData/BssEpisode.cs
@@ -3,9 +3,9 @@ public class BssEpisode
 {
     public long episode_id { get; set; }
     public long nhs_number { get; set; }
-    public string? episode_type { get; set; }
+    public required string episode_type { get; set; }
     public DateTime change_db_date_time { get; set; }
-    public string? episode_date { get; set; }
+    public required string episode_date { get; set; }
     public string? appointment_made { get; set; }
     public string? date_of_foa { get; set; }
     public string? date_of_as { get; set; }

--- a/src/EpisodeIntegrationService/ReceiveData/ReceiveData.cs
+++ b/src/EpisodeIntegrationService/ReceiveData/ReceiveData.cs
@@ -60,7 +60,7 @@ public class ReceiveData
             {
                 if (!CheckCsvFileHeaders(myBlob, FileType.Episodes))
                 {
-                    _logger.LogError("Episodes CSV file headers are invalid.");
+                    _logger.LogError("Episodes CSV file headers are invalid. file name: {Name}", name);
                     return;
                 }
 
@@ -95,7 +95,7 @@ public class ReceiveData
             {
                 if (!CheckCsvFileHeaders(myBlob, FileType.Subjects))
                 {
-                    _logger.LogError("Subjects CSV file headers are invalid.");
+                    _logger.LogError("Subjects CSV file headers are invalid. file name: {Name}", name);
                     return;
                 }
 
@@ -232,6 +232,7 @@ public class ReceiveData
 
     private InitialEpisodeDto MapEpisodeToEpisodeDto(BssEpisode episode)
     {
+        Utils.CheckForNullOrEmptyStrings(episode.episode_type, episode.episode_date);
         return new InitialEpisodeDto
         {
             EpisodeId = episode.episode_id,
@@ -256,6 +257,7 @@ public class ReceiveData
     }
     private async Task<FinalizedEpisodeDto> MapHistoricalEpisodeToEpisodeDto(BssEpisode episode, EpisodeReferenceData referenceData, OrganisationReferenceData organisationReferenceData)
     {
+        Utils.CheckForNullOrEmptyStrings(episode.episode_type, episode.episode_date);
         var finalizedEpisodeDto = new FinalizedEpisodeDto
         {
             EpisodeId = episode.episode_id,

--- a/src/EpisodeIntegrationService/ReceiveData/Utils.cs
+++ b/src/EpisodeIntegrationService/ReceiveData/Utils.cs
@@ -35,4 +35,15 @@ public static class Utils
         return DateTime.ParseExact(dateTime, format, CultureInfo.InvariantCulture, DateTimeStyles.None);
     }
 
+    public static void CheckForNullOrEmptyStrings(params string[] values)
+    {
+        foreach (var value in values)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                throw new ArgumentException($"Value cannot be null or empty: {value}");
+            }
+        }
+    }
+
 }

--- a/tests/EpisodeIntegrationServiceTests/ReceiveDataTests/ReceiveDataTests.cs
+++ b/tests/EpisodeIntegrationServiceTests/ReceiveDataTests/ReceiveDataTests.cs
@@ -475,7 +475,7 @@ public class ReceiveDataTests
             log.Log(
             LogLevel.Error,
             0,
-            It.Is<object>(state => state.ToString() == "Episodes CSV file headers are invalid."),
+            It.Is<object>(state => state.ToString() == "Episodes CSV file headers are invalid. file name: bss_episodes_test_data_20240930.csv"),
             null,
             (Func<object, Exception, string>)It.IsAny<object>()),
             Times.Once);
@@ -503,7 +503,7 @@ public class ReceiveDataTests
             log.Log(
             LogLevel.Error,
             0,
-            It.Is<object>(state => state.ToString().Contains("Subjects CSV file headers are invalid.")),
+            It.Is<object>(state => state.ToString() == "Subjects CSV file headers are invalid. file name: bss_subjects_test_data_20240930.csv"),
             null,
             (Func<object, Exception, string>)It.IsAny<object>()),
             Times.Once);


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- Update ReceiveData function to display file name when schema validation fails
- Update ReceiveData function to validate episode_type and episode_date
- Add CheckForNullOrEmptyStrings method in Utils,cs to validate mandatory attributes
- Update unit tests to display file name when schema validation fails

## Context

https://nhsd-jira.digital.nhs.uk/browse/DTOSS-7042

https://nhsd-jira.digital.nhs.uk/browse/DTOSS-7057



## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
