### PR TITLE
fix: Src system processed datetime was not set for episodes

### DIFF
--- a/src/EpisodeDataService/CreateEpisode/CreateEpisode.cs
+++ b/src/EpisodeDataService/CreateEpisode/CreateEpisode.cs
@@ -129,6 +129,7 @@ public class CreateEpisode
             OrganisationId = 111111, // Need to get OrganisationId from Reference Management Data Store
             BatchId = episodeDto.BatchId,
             ExceptionFlag = exceptionFlag ? (short)1 : (short)0,
+            SrcSysProcessedDatetime = episodeDto.SrcSysProcessedDateTime,
             RecordInsertDatetime = DateTime.UtcNow,
             RecordUpdateDatetime = DateTime.UtcNow
         };

--- a/src/EpisodeDataService/UpdateEpisode/UpdateEpisode.cs
+++ b/src/EpisodeDataService/UpdateEpisode/UpdateEpisode.cs
@@ -65,6 +65,8 @@ public class UpdateEpisode
                 return req.CreateResponse(HttpStatusCode.NotFound);
             }
 
+            bool shouldUpdate = episodeDto.SrcSysProcessedDateTime > existingEpisode.SrcSysProcessedDatetime;
+
             var checkParticipantExistsUrl = $"{Environment.GetEnvironmentVariable("CheckParticipantExistsUrl")}?NhsNumber={episodeDto.NhsNumber}&ScreeningId={ScreeningId}";
             var checkParticipantExistsResult = await _httpRequestService.SendGet(checkParticipantExistsUrl);
             // If the participant does not exist then flag as an exception
@@ -76,8 +78,6 @@ public class UpdateEpisode
             FinalActionCodeLkp? finalActionCodeLkp = await GetCodeObject<FinalActionCodeLkp?>(episodeDto.FinalActionCode, "Final action code", _finalActionCodeLkpRepository.GetFinalActionCodeLkp);
 
             existingEpisode = await MapEpisodeDtoToEpisode(existingEpisode, episodeDto, episodeTypeLkp?.EpisodeTypeId, endCodeLkp?.EndCodeId, reasonClosedCodeLkp?.ReasonClosedCodeId, finalActionCodeLkp?.FinalActionCodeId, exceptionFlag);
-
-            bool shouldUpdate = episodeDto.SrcSysProcessedDateTime > existingEpisode.SrcSysProcessedDatetime;
 
             if (shouldUpdate)
             {

--- a/src/EpisodeDataService/UpdateEpisode/UpdateEpisode.cs
+++ b/src/EpisodeDataService/UpdateEpisode/UpdateEpisode.cs
@@ -143,6 +143,7 @@ public class UpdateEpisode
         existingEpisode.OrganisationId = 111111; // Need to get OrganisationId from Reference Management Data Store
         existingEpisode.BatchId = episodeDto.BatchId;
         existingEpisode.ExceptionFlag = exceptionFlag ? (short)1 : (short)0;
+        existingEpisode.SrcSysProcessedDatetime = episodeDto.SrcSysProcessedDateTime;
         existingEpisode.RecordUpdateDatetime = DateTime.UtcNow;
         return existingEpisode;
     }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Sets the SrcSysProcessedDatetime property when creating and updating episodes.

## Context

The SrcSysProcessedDatetime not being set would impact the ability of the Episode Manager to determine if the incoming data is more up to date than what is already stored in the data store for that episode.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
