### PR TITLE
fix: include src system processed datetime in event

### DIFF
--- a/src/EpisodeDataService/CreateEpisode/CreateEpisode.cs
+++ b/src/EpisodeDataService/CreateEpisode/CreateEpisode.cs
@@ -126,7 +126,7 @@ public class CreateEpisode
             ReasonClosedCodeId = reasonClosedCodeId,
             FinalActionCodeId = finalActionCodeId,
             EndPoint = episodeDto.EndPoint,
-            OrganisationId = 111111, // Need to get OrganisationId from Reference Management Data Store
+            OrganisationId = 2, // Need to get OrganisationId from Reference Management Data Store
             BatchId = episodeDto.BatchId,
             ExceptionFlag = exceptionFlag ? (short)1 : (short)0,
             SrcSysProcessedDatetime = episodeDto.SrcSysProcessedDateTime,

--- a/src/EpisodeDataService/UpdateEpisode/UpdateEpisode.cs
+++ b/src/EpisodeDataService/UpdateEpisode/UpdateEpisode.cs
@@ -140,7 +140,7 @@ public class UpdateEpisode
         existingEpisode.ReasonClosedCodeId = reasonClosedCodeId;
         existingEpisode.FinalActionCodeId = finalActionCodeId;
         existingEpisode.EndPoint = episodeDto.EndPoint;
-        existingEpisode.OrganisationId = 111111; // Need to get OrganisationId from Reference Management Data Store
+        existingEpisode.OrganisationId = 2; // Need to get OrganisationId from Reference Management Data Store
         existingEpisode.BatchId = episodeDto.BatchId;
         existingEpisode.ExceptionFlag = exceptionFlag ? (short)1 : (short)0;
         existingEpisode.SrcSysProcessedDatetime = episodeDto.SrcSysProcessedDateTime;

--- a/src/Shared/Model/Dtos/FinalizedEpisodeDto.cs
+++ b/src/Shared/Model/Dtos/FinalizedEpisodeDto.cs
@@ -46,7 +46,7 @@ public class FinalizedEpisodeDto
 
     public short? ExceptionFlag { get; set; }
 
-    public DateTime SrcSysProcessedDatetime { get; set; }
+    public DateTime? SrcSysProcessedDatetime { get; set; }
 
     public static explicit operator FinalizedEpisodeDto(Episode episode)
     {
@@ -65,7 +65,8 @@ public class FinalizedEpisodeDto
             EndPoint = episode.EndPoint,
             OrganisationId = episode.OrganisationId,
             BatchId = episode.BatchId,
-            ExceptionFlag = episode.ExceptionFlag
+            ExceptionFlag = episode.ExceptionFlag,
+            SrcSysProcessedDatetime = episode.SrcSysProcessedDatetime
         };
     }
 }

--- a/src/Shared/Model/Dtos/FinalizedEpisodeDto.cs
+++ b/src/Shared/Model/Dtos/FinalizedEpisodeDto.cs
@@ -46,7 +46,7 @@ public class FinalizedEpisodeDto
 
     public short? ExceptionFlag { get; set; }
 
-    public DateTime? SrcSysProcessedDatetime { get; set; }
+    public DateTime SrcSysProcessedDatetime { get; set; }
 
     public static explicit operator FinalizedEpisodeDto(Episode episode)
     {
@@ -66,7 +66,7 @@ public class FinalizedEpisodeDto
             OrganisationId = episode.OrganisationId,
             BatchId = episode.BatchId,
             ExceptionFlag = episode.ExceptionFlag,
-            SrcSysProcessedDatetime = episode.SrcSysProcessedDatetime
+            SrcSysProcessedDatetime = (DateTime)episode.SrcSysProcessedDatetime
         };
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

1. Included the source system processed datetime in the events as it was missing
2. Changed the hardcoded organisation id to a valid value as a temporary fix until [DTOSS-6985](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-6985) is done

## Context

To fix bugs

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
