### PR TITLE
fix: display error for invalid value for appointment_made field of Episode

### DIFF
--- a/src/EpisodeIntegrationService/ReceiveData/ReceiveData.cs
+++ b/src/EpisodeIntegrationService/ReceiveData/ReceiveData.cs
@@ -233,6 +233,7 @@ public class ReceiveData
     private InitialEpisodeDto MapEpisodeToEpisodeDto(BssEpisode episode)
     {
         Utils.CheckForNullOrEmptyStrings(episode.episode_type, episode.episode_date);
+        Utils.ValidateDataValue(episode.appointment_made);
         return new InitialEpisodeDto
         {
             EpisodeId = episode.episode_id,
@@ -258,6 +259,7 @@ public class ReceiveData
     private async Task<FinalizedEpisodeDto> MapHistoricalEpisodeToEpisodeDto(BssEpisode episode, EpisodeReferenceData referenceData, OrganisationReferenceData organisationReferenceData)
     {
         Utils.CheckForNullOrEmptyStrings(episode.episode_type, episode.episode_date);
+        Utils.ValidateDataValue(episode.appointment_made);
         var finalizedEpisodeDto = new FinalizedEpisodeDto
         {
             EpisodeId = episode.episode_id,

--- a/src/EpisodeIntegrationService/ReceiveData/Utils.cs
+++ b/src/EpisodeIntegrationService/ReceiveData/Utils.cs
@@ -42,4 +42,12 @@ public static class Utils
             throw new ArgumentException("Value cannot be null or empty");
         }
     }
+
+    public static void ValidateDataValue(string dataValue)
+    {
+        if (!string.IsNullOrWhiteSpace(dataValue) && dataValue.ToLower() != "true" && dataValue.ToLower() != "false")
+        {
+            throw new Exception($"Invalid value: {dataValue}. Expected 'true', 'false', null, or an empty string");
+        }
+    }
 }

--- a/src/EpisodeIntegrationService/ReceiveData/Utils.cs
+++ b/src/EpisodeIntegrationService/ReceiveData/Utils.cs
@@ -47,7 +47,7 @@ public static class Utils
     {
         if (!string.IsNullOrWhiteSpace(dataValue) && dataValue.ToLower() != "true" && dataValue.ToLower() != "false")
         {
-            throw new Exception($"Invalid value: {dataValue}. Expected 'true', 'false', null, or an empty string");
+            throw new ArgumentException($"Invalid value: {dataValue}. Expected 'true', 'false', null, or an empty string");
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Update ReceiveData function to display error for invalid value for appointment_made field of Episode

## Context

Bug fix - https://nhsd-jira.digital.nhs.uk/browse/DTOSS-7063

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
