### PR TITLE
fix: End Code Last Updated one hour shift

### DIFF
--- a/src/EpisodeIntegrationService/ReceiveData/Utils.cs
+++ b/src/EpisodeIntegrationService/ReceiveData/Utils.cs
@@ -32,7 +32,7 @@ public static class Utils
     {
         if (string.IsNullOrEmpty(dateTime)) return null;
 
-        return DateTime.ParseExact(dateTime, format, CultureInfo.InvariantCulture, DateTimeStyles.None);
+        return DateTime.ParseExact(dateTime, format, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal);
     }
 
     public static void CheckForNullOrEmptyStrings(params string[] values)


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Changed DateTimeStyles.None to DateTimeStyles.AssumeLocal to make sure that the date formatting for end_code_last_updated would be processed correctly and would take into account the local time. 

## Context

end_code_last_updated in the csv file was not being processed correctly and would receive a 1 hour deduction off of its time. 

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [x] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
