### PR TITLE
fix: Created a null check for create ps episode so that the function can handle a null Organisation ID and populate the Participant Screening Episode table

### DIFF
--- a/src/BIAnalyticsManagementService/CreateParticipantScreeningEpisode/CreateParticipantScreeningEpisode.cs
+++ b/src/BIAnalyticsManagementService/CreateParticipantScreeningEpisode/CreateParticipantScreeningEpisode.cs
@@ -88,6 +88,12 @@ public class CreateParticipantScreeningEpisode
 
     private async Task<OrganisationLkp> GetOrganisationDataAsync(long? organisationId)
     {
+        if (organisationId == null)
+        {
+            _logger.LogInformation("Organisation id is null... Setting Organisation Name and Code to null");
+            return null;
+        }
+
         var baseReferenceServiceUrl = Environment.GetEnvironmentVariable("GetReferenceDataUrl");
         var getReferenceDataUrl = $"{baseReferenceServiceUrl}?organisation_id={organisationId}";
         _logger.LogInformation("Requesting organisation data from {Url}", getReferenceDataUrl);
@@ -130,8 +136,8 @@ public class CreateParticipantScreeningEpisode
             ReasonClosedCodeDescription = episode.ReasonClosedCodeDescription,
             FinalActionCode =  episode.FinalActionCode,
             FinalActionCodeDescription = episode.FinalActionCodeDescription,
-            OrganisationCode = organisationLkp.OrganisationCode,
-            OrganisationName = organisationLkp.OrganisationName,
+            OrganisationCode = organisationLkp?.OrganisationCode,
+            OrganisationName = organisationLkp?.OrganisationName,
             BatchId = episode.BatchId,
             SrcSysProcessedDatetime = episode.SrcSysProcessedDatetime,
             RecordInsertDatetime = isHistoric ? episode.SrcSysProcessedDatetime.AddDays(1) : DateTime.UtcNow,

--- a/src/EpisodeDataService/UpdateEpisode/UpdateEpisode.cs
+++ b/src/EpisodeDataService/UpdateEpisode/UpdateEpisode.cs
@@ -160,7 +160,7 @@ public class UpdateEpisode(ILogger<UpdateEpisode> logger, IEpisodeRepository epi
     {
         if (string.IsNullOrWhiteSpace(organisationCode))
         {
-            _logger.LogInformation("Organisation id is null");
+            _logger.LogInformation("Organisation code is null");
             return null;
         }
 


### PR DESCRIPTION

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Created a null check in Create PS Episode so that the function is able to process a null organisation id. Previously I had done this for Create and Update Episode. A tested identified an issue wherein a null organisation id was stopping the Create and Update Episode functions from populating the Episode table. So we had missing data rows for episodes that didn't have an organisation code in the raw csv. I added a null check for both of those originally. However, this change meant that they didn't have an organisation id in the Episode table -- without which, we can't populate the PS Episode table with the org code and name. 

Hence why I had to go further downstream to ensure Create PS Episode could handle a null organisation id and return null for org name and code... and populate the table with those values. 

I also spotted a typo in UpdateEpisode, which I corrected. 

## Context

Create PS Episode wouldn't populate the Participant Screening Episode table because it couldn't handle a null organisation ID. 

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [x] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
