### PR TITLE
fix: Move the DLQ storage account to the project subscription vnet

### DIFF
--- a/infrastructure/tf-core/event_grid.tf
+++ b/infrastructure/tf-core/event_grid.tf
@@ -10,7 +10,7 @@ module "event_grid_subscription" {
   principal_id         = module.functionapp["${each.value.subscriber_functionName}-${each.value.region}"].function_app_sami_id
 
   dead_letter_storage_account_container_name = "deadletterqueue"
-  dead_letter_storage_account_id             = data.terraform_remote_state.hub.outputs.storage["eventgrid-uksouth"].storage_account_id
+  dead_letter_storage_account_id             = module.storage["eventgrid-${each.value.region}"].storage_account_id
 
   tags = var.tags
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Point the DLQ storage account in the  project subscription vnet to the function Apps. 

Likely will want to use the DLQ in the HUB once we have proper cross project events occurring. 

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
