### PR TITLE
fix: make gitleaks ignore Reqnroll versions

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,3 +1,16 @@
 # SEE: https://github.com/gitleaks/gitleaks/blob/master/README.md#gitleaksignore
 
 cd9c0efec38c5d63053dd865e5d4e207c0760d91:docs/guides/Perform_static_analysis.md:generic-api-key:37
+
+# Reqnroll: auto-generated version numbers
+56fac0623cf8c4d6d37a7b4fe485b886ecdb8ab0:tests/SmokeTests/dtos-service-insights-tests/Features/EpisodeDataService.feature.cs:ipv4:4
+56fac0623cf8c4d6d37a7b4fe485b886ecdb8ab0:tests/SmokeTests/dtos-service-insights-tests/Features/EpisodeDataService.feature.cs:ipv4:5
+56fac0623cf8c4d6d37a7b4fe485b886ecdb8ab0:tests/SmokeTests/dtos-service-insights-tests/Features/EpisodeDataService.feature.cs:ipv4:20
+
+6db59f82affa41635d2d70e83bdfecd62a7a9ace:tests/SmokeTests/dtos-service-insights-tests/dtos-service-insights-tests/Features/EpisodeDataService.feature.cs:ipv4:4
+6db59f82affa41635d2d70e83bdfecd62a7a9ace:tests/SmokeTests/dtos-service-insights-tests/dtos-service-insights-tests/Features/EpisodeDataService.feature.cs:ipv4:5
+6db59f82affa41635d2d70e83bdfecd62a7a9ace:tests/SmokeTests/dtos-service-insights-tests/dtos-service-insights-tests/Features/EpisodeDataService.feature.cs:ipv4:20
+
+54585a234ad83ac2a70e2dc8a2c681151c199e6f:tests/SmokeTests/dtos-service-insights-tests/Features/EpisodeDataService.feature.cs:ipv4:4
+54585a234ad83ac2a70e2dc8a2c681151c199e6f:tests/SmokeTests/dtos-service-insights-tests/Features/EpisodeDataService.feature.cs:ipv4:5
+54585a234ad83ac2a70e2dc8a2c681151c199e6f:tests/SmokeTests/dtos-service-insights-tests/Features/EpisodeDataService.feature.cs:ipv4:20


### PR DESCRIPTION
Auto-generated Reqnroll versions are mistakenly flagged as ipv4 addresses by gitleaks.

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [x] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
