### PR TITLE
fix: ReceiveData adjusts SrcSysProcessedDateTime to UTC

### DIFF
--- a/src/EpisodeIntegrationService/ReceiveData/ReceiveData.cs
+++ b/src/EpisodeIntegrationService/ReceiveData/ReceiveData.cs
@@ -264,7 +264,7 @@ public class ReceiveData
             EpisodeType = episode.episode_type,
             ScreeningName = "Breast Screening",
             NhsNumber = long.Parse(episode.nhs_number),
-            SrcSysProcessedDateTime = DateTime.Parse(episode.change_db_date_time, CultureInfo.InvariantCulture, DateTimeStyles.None),
+            SrcSysProcessedDateTime = DateTime.Parse(episode.change_db_date_time, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal),
             EpisodeOpenDate = Utils.ParseNullableDate(episode.episode_date),
             AppointmentMadeFlag = Utils.ParseBooleanStringToShort(episode.appointment_made),
             FirstOfferedAppointmentDate = Utils.ParseNullableDate(episode.date_of_foa),
@@ -308,7 +308,7 @@ public class ReceiveData
             EndPoint = episode.end_point,
             OrganisationId = string.IsNullOrEmpty(episode.bso_organisation_code) ? null : organisationReferenceData.OrganisationCodeToIdLookup[episode.bso_organisation_code],
             BatchId = episode.bso_batch_id,
-            SrcSysProcessedDatetime = DateTime.Parse(episode.change_db_date_time, CultureInfo.InvariantCulture, DateTimeStyles.None)
+            SrcSysProcessedDatetime = DateTime.Parse(episode.change_db_date_time, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal)
         };
 
         return finalizedEpisodeDto;

--- a/tests/EpisodeIntegrationServiceTests/ReceiveDataTests/ReceiveDataTests.cs
+++ b/tests/EpisodeIntegrationServiceTests/ReceiveDataTests/ReceiveDataTests.cs
@@ -93,7 +93,7 @@ public class ReceiveDataTests
             EpisodeType = "R",
             ScreeningName = "Breast Screening",
             NhsNumber = 9000007053,
-            SrcSysProcessedDateTime = DateTime.Parse("2020-03-31 12:11:47.339148+01"),
+            SrcSysProcessedDateTime = DateTime.Parse("2020-03-31 12:11:47.339148+01").ToUniversalTime(),
             EpisodeOpenDate = DateOnly.Parse("2017-01-11"),
             AppointmentMadeFlag = 1,
             FirstOfferedAppointmentDate = DateOnly.Parse("2017-03-14"),


### PR DESCRIPTION

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Updated the Episode DTO mapping to convert SrcSysProcessedDateTime to UTC when processed.

## Context

It ensures that UTC is a standard when processing Date Time in the episode dto.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [x] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
